### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve.
+title: ''
+assignees: ''
+---
+
+<!--
+
+    Please do *NOT* ask usage questions in Github issues.
+
+    If your issue is not a feature request or bug report use our community support.
+
+    https://prometheus.io/community/
+
+-->
+
+**What did you do?**
+
+**What did you expect to see?**
+
+**What did you see instead? Under which circumstances?**
+
+**Environment**
+
+* System information:
+
+	insert output of `uname -srm` here
+
+* postgres_exporter version:
+
+	insert output of `postgres_exporter --version` here
+
+* postgres_exporter flags:
+
+```
+insert list of flags used here
+```
+
+* PostgresSQL version:
+
+	insert PostgreSQL version here
+
+* Logs:
+```
+insert logs relevant to the issue here
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Prometheus community support
+    url: https://prometheus.io/community/
+    about: List of communication channels for the Prometheus community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+
+    Please do *NOT* ask usage questions in Github issues.
+
+    If your issue is not a feature request or bug report use our community support.
+
+    https://prometheus.io/community/
+
+-->
+## Proposal
+**Use case. Why is this important?**
+
+*“Nice to have” is not a good use case. :)*


### PR DESCRIPTION
Add templates to point users towards the community support channels.

Signed-off-by: Ben Kochie <superq@gmail.com>