### PR TITLE
fix parsing include databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ flag. This removes all built-in metrics, and uses only metrics defined by querie
 (so you must supply one, otherwise the exporter will return nothing but internal statuses and not your database).
 
 ### Automatically discover databases
-To scrape metrics from all databases on a database server, the database DSN's can be dynamically discovered via the 
-`--auto-discover-databases` flag. When true, `SELECT datname FROM pg_database WHERE datallowconn = true AND datistemplate = false and datname != current_database()` is run for all configured DSN's. From the 
+To scrape metrics from all databases on a database server, the database DSN's can be dynamically discovered via the
+`--auto-discover-databases` flag. When true, `SELECT datname FROM pg_database WHERE datallowconn = true AND datistemplate = false and datname != current_database()` is run for all configured DSN's. From the
 result a new set of DSN's is created for which the metrics are scraped.
 
 In addition, the option `--exclude-databases` adds the possibily to filter the result from the auto discovery to discard databases you do not need.
@@ -285,3 +285,14 @@ GRANT SELECT ON postgres_exporter.pg_stat_statements TO postgres_exporter;
 > ```
 > DATA_SOURCE_NAME=postgresql://postgres_exporter:password@localhost:5432/postgres?sslmode=disable
 > ```
+
+
+## Running the tests
+```
+# Run the unit tests
+make test
+# Start the test database with docker
+docker run -p 5432:5432 -e POSTGRES_DB=circle_test -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=test -d postgres
+# Run the integration tests
+DATA_SOURCE_NAME='postgresql://postgres:test@localhost:5432/circle_test?sslmode=disable' GOOPTS='-v -tags integration' make test
+```

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1149,7 +1149,9 @@ func ExcludeDatabases(s string) ExporterOpt {
 // IncludeDatabases allows to filter result from AutoDiscoverDatabases
 func IncludeDatabases(s string) ExporterOpt {
 	return func(e *Exporter) {
-		e.includeDatabases = strings.Split(s, ",")
+		if len(s) > 0 {
+			e.includeDatabases = strings.Split(s, ",")
+		}
 	}
 }
 

--- a/cmd/postgres_exporter/postgres_exporter_integration_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_integration_test.go
@@ -162,3 +162,16 @@ func (s *IntegrationSuite) TestExtendQueriesDoesntCrash(c *C) {
 	// scrape the exporter and make sure it works
 	exporter.scrape(ch)
 }
+
+func (s *IntegrationSuite) TestAutoDiscoverDatabases(c *C) {
+	dsn := os.Getenv("DATA_SOURCE_NAME")
+
+	exporter := NewExporter(
+		strings.Split(dsn, ","),
+	)
+	c.Assert(exporter, NotNil)
+
+	dsns := exporter.discoverDatabaseDSNs()
+
+	c.Assert(len(dsns), Equals, 2)
+}


### PR DESCRIPTION
The introduction of the include databases flag disables the auto discovery flag completely, this PR will fix that.