### PR TITLE
pg_process_idle should be called only once database in instance

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -265,6 +265,7 @@ pg_process_idle:
       ARRAY_AGG(bucket) AS seconds_bucket
     FROM metrics JOIN buckets USING (application_name)
     GROUP BY 1, 2, 3
+  master: true
   metrics:
     - application_name:
         usage: "LABEL"


### PR DESCRIPTION
If `auto-discover-databases` is enabled, postgres_exporter will return 500 status.
- postgres_exporter version 0.9.0.
- The error message:
```
....
* collected metric "pg_process_idle_seconds" { label:<name:"application_name" value:"PostgreSQL JDBC Driver" > label:<name:"server" value:"127.0.0.1:5432" > histogram:<sample_count:5 sample_sum:1256 bucket:<cumulative_count:0 upper_bound:1 > bucket:<cumulative_count:0 upper_bound:2 > bucket:<cumulative_count:0 upper_bound:5 > bucket:<cumulative_count:0 upper_bound:15 > bucket:<cumulative_count:0 upper_bound:30 > bucket:<cumulative_count:1 upper_bound:60 > bucket:<cumulative_count:2 upper_bound:90 > bucket:<cumulative_count:2 upper_bound:120 > bucket:<cumulative_count:4 upper_bound:300 > > } was collected before with the same name and label values
* collected metric "pg_process_idle_seconds" { label:<name:"application_name" value:"vertx-pg-client" > label:<name:"server" value:"127.0.0.1:5432" > histogram:<sample_count:4 sample_sum:596 bucket:<cumulative_count:0 upper_bound:1 > bucket:<cumulative_count:0 upper_bound:2 > bucket:<cumulative_count:0 upper_bound:5 > bucket:<cumulative_count:0 upper_bound:15 > bucket:<cumulative_count:0 upper_bound:30 > bucket:<cumulative_count:0 upper_bound:60 > bucket:<cumulative_count:0 upper_bound:90 > bucket:<cumulative_count:0 upper_bound:120 > bucket:<cumulative_count:4 upper_bound:300 > > } was collected before with the same name and label values
```