### PR TITLE
Improve PostgreSQL replication lag detection in low traffic PostgreSQL cluster

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1,5 +1,13 @@
 pg_replication:
-  query: "SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag"
+  query: |
+    SELECT
+    CASE WHEN NOT pg_is_in_recovery() THEN
+        0
+    WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN
+        0
+    ELSE
+        GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
+    END AS lag
   master: true
   metrics:
     - lag:


### PR DESCRIPTION
In case the query `pg_replication` run in the slave which currently has no database traffic (for example in the middle of the night), the exporter will show an incorrect lag value.

Example from idle PostgreSQL cluster:
- Current WAL lsn (from master)
```
# select pg_current_wal_lsn();
 pg_current_wal_lsn
--------------------
 1/3E029AE8
(1 row)
```
- Current WAL recevice lsn (from slave)
```
# select pg_last_wal_receive_lsn();
 pg_last_wal_receive_lsn
-------------------------
 1/3E029AE8
(1 row)
```
- Current WAL replay lsn (from slave)
```
# select pg_last_wal_replay_lsn();
 pg_last_wal_replay_lsn
------------------------
 1/3E029AE8
(1 row)
```
- Current replication lag (from slave)
```
# SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag;
     lag
-------------
 7466.495493
(1 row)
```
- Improved query (from slave) 
```
# SELECT
    CASE WHEN NOT pg_is_in_recovery() THEN
        0
    WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN
        0
    ELSE
        GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
    END AS lag;
 lag
-----
   0
(1 row)
```