### PR TITLE
Have 0 lag if database is not updated

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1,5 +1,12 @@
 pg_replication:
-  query: "SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag"
+  query: |
+    SELECT
+      CASE
+        WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()
+        OR NOT pg_is_in_recovery()
+          THEN 0
+          ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
+      END AS lag
   master: true
   metrics:
     - lag:


### PR DESCRIPTION
I found the lag metric increasing over night when there are no commits in the database. Setting the lag to `0` when the `pg_last_wal_receive_lsn` and `pg_last_wal_replay_lsn` values are equal seems to have solved that problem.