### PR TITLE
feat: allow multiple workers

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -42,6 +42,7 @@ var (
 	excludeDatabases       = kingpin.Flag("exclude-databases", "A list of databases to remove when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_EXCLUDE_DATABASES").String()
 	includeDatabases       = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
 	metricPrefix           = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
+	workers                = kingpin.Flag("workers", "The number of workers use for scraping").Default("1").Envar("PG_EXPORTER_WORKERS").Int()
 	logger                 = log.NewNopLogger()
 )
 
@@ -103,6 +104,7 @@ func main() {
 		WithConstantLabels(*constantLabelsList),
 		ExcludeDatabases(*excludeDatabases),
 		IncludeDatabases(*includeDatabases),
+		Workers(workers),
 	}
 
 	exporter := NewExporter(dsn, opts...)

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/blang/semver"
@@ -468,6 +470,7 @@ type Exporter struct {
 	psqlUp           prometheus.Gauge
 	userQueriesError *prometheus.GaugeVec
 	totalScrapes     prometheus.Counter
+	workers          *int
 
 	// servers are used to allow re-using the DB connection between scrapes.
 	// servers contains metrics map and query overrides.
@@ -518,6 +521,13 @@ func IncludeDatabases(s string) ExporterOpt {
 func WithUserQueriesPath(p string) ExporterOpt {
 	return func(e *Exporter) {
 		e.userQueriesPath = p
+	}
+}
+
+// Workers configures the number of scrape workers
+func Workers(i *int) ExporterOpt {
+	return func(e *Exporter) {
+		e.workers = i
 	}
 }
 
@@ -721,23 +731,47 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		dsns = e.discoverDatabaseDSNs()
 	}
 
-	var errorsCount int
-	var connectionErrorsCount int
+	var errorsCount int32
+	var connectionErrorsCount int32
 
-	for _, dsn := range dsns {
-		if err := e.scrapeDSN(ch, dsn); err != nil {
-			errorsCount++
+	dsnsToScrape := make(chan string, len(dsns))
+	var wg sync.WaitGroup
 
-			level.Error(logger).Log("err", err)
-
-			if _, ok := err.(*ErrorConnectToServer); ok {
-				connectionErrorsCount++
-			}
-		}
+	var workers int
+	if e.workers != nil {
+		workers = *e.workers
+	} else {
+		workers = 1
 	}
 
+	for i := 1; i <= workers; i++ {
+		wg.Add(1)
+		go func(dsns chan string, wg *sync.WaitGroup) {
+			defer wg.Done()
+
+			for dsn := range dsns {
+				if err := e.scrapeDSN(ch, dsn); err != nil {
+					errorsCount++
+					atomic.AddInt32(&errorsCount, 1)
+
+					level.Error(logger).Log("err", err)
+					if _, ok := err.(*ErrorConnectToServer); ok {
+						atomic.AddInt32(&connectionErrorsCount, 1)
+					}
+				}
+			}
+		}(dsnsToScrape, &wg)
+	}
+
+	for _, dsn := range dsns {
+		dsnsToScrape <- dsn
+	}
+	close(dsnsToScrape)
+
+	wg.Wait()
+
 	switch {
-	case connectionErrorsCount >= len(dsns):
+	case int(connectionErrorsCount) >= len(dsns):
 		e.psqlUp.Set(0)
 	default:
 		e.psqlUp.Set(1) // Didn't fail, can mark connection as up for this scrape.


### PR DESCRIPTION
Allow to use multiple scrape workers instead of only 1.

This improves collection time when scraping multiple databases.