### PR TITLE
Add error prone SQL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ AS
 
 GRANT SELECT ON postgres_exporter.pg_stat_replication TO postgres_exporter;
 
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 CREATE OR REPLACE FUNCTION get_pg_stat_statements() RETURNS SETOF pg_stat_statements AS
 $$ SELECT * FROM public.pg_stat_statements; $$
 LANGUAGE sql


### PR DESCRIPTION
Getting the error when adding non-root postgres user for exporter:
```
postgres=# CREATE OR REPLACE FUNCTION get_pg_stat_statements() RETURNS SETOF pg_stat_statements AS
postgres-# $$ SELECT * FROM public.pg_stat_statements; $$
postgres-# LANGUAGE sql
postgres-# VOLATILE
postgres-# SECURITY DEFINER;
ERROR:  type "pg_stat_statements" does not exist
```
Add following sql command for enable pg_stat_statements:
```
CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
```