### PR TITLE
fix: command arguments

### DIFF
--- a/postgres_exporter.rc
+++ b/postgres_exporter.rc
@@ -72,7 +72,7 @@ pidfile=/var/run/postgres_exporter.pid
 command="/usr/sbin/daemon"
 procname="/usr/local/bin/postgres_exporter"
 command_args="-p ${pidfile} /usr/bin/env DATA_SOURCE_NAME="${postgres_exporter_data_source_name}" ${procname} \
-    -web.listen-address=${postgres_exporter_listen_address} \
+    --web.listen-address=${postgres_exporter_listen_address} \
     ${postgres_exporter_args}"
 
 start_precmd=postgres_exporter_startprecmd


### PR DESCRIPTION
It needs two dashes, otherwise, it won't work.