### PR TITLE
Avoid parsing error from bogus Azure Flexible Server custom GUC

### DIFF
--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -31,7 +31,7 @@ func querySettings(ch chan<- prometheus.Metric, server *Server) error {
 	//
 	// NOTE: If you add more vartypes here, you must update the supported
 	// types in normaliseUnit() below
-	query := "SELECT name, setting, COALESCE(unit, ''), short_desc, vartype FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real');"
+	query := "SELECT name, setting, COALESCE(unit, ''), short_desc, vartype FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real') AND name != 'sync_commit_cancel_wait';"
 
 	rows, err := server.db.Query(query)
 	if err != nil {


### PR DESCRIPTION
Azure Flexible Server (currently in preview but slated to become generally available before the end of the year) apparently added a custom GUC with type int, but their default value is `Disabled`, breaking postgres_exporter:

```
=> SELECT name, setting, vartype, COALESCE(unit, ''), short_desc FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real') AND name = 'sync_commit_cancel_wait';                                   
          name           | setting  | vartype | coalesce |                                    short_desc                                     
-------------------------+----------+---------+----------+-----------------------------------------------------------------------------------
 sync_commit_cancel_wait | Disabled | integer |          | Allow cancellation of waiting for replication of a transaction committed locally.
```
This is the error:
```
panic: Error converting setting "sync_commit_cancel_wait" value "Disabled" to float: strconv.ParseFloat: parsing "Disabled": invalid syntax
goroutine 43 [running]:
main.(*pgSetting).metric(0xc0003bd860, 0xc00021b260, 0x5, 0x5)
    /app/cmd/postgres_exporter/pg_setting.go:80 +0x4f9
main.querySettings(0xc000200480, 0xc00029e210, 0x0, 0x0)
    /app/cmd/postgres_exporter/pg_setting.go:49 +0x305
main.(*Server).Scrape(0xc00029e210, 0xc000200480, 0xc00029e200, 0x0, 0x0)
    /app/cmd/postgres_exporter/server.go:121 +0x1a5
main.(*Exporter).scrapeDSN(0xc0002d6000, 0xc000200480, 0xc0002d4000, 0x78, 0x2, 0x0)
    /app/cmd/postgres_exporter/datasource.go:116 +0xed
main.(*Exporter).scrape(0xc0002d6000, 0xc000200480)
    /app/cmd/postgres_exporter/postgres_exporter.go:728 +0x145
main.(*Exporter).Collect(0xc0002d6000, 0xc000200480)
    /app/cmd/postgres_exporter/postgres_exporter.go:617 +0x39
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
    /go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/registry.go:448 +0x154
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
    /go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/registry.go:538 +0xe4d
```

I have reported this to Microsoft, but fixing this would require changing the source and making a release, so I do not anticipate a quick turnaround time for a fix.
In order to use postgres_exporter with Azure Flexible Server in the meantime, we use this hot-fix which I am also submitting here, but I can understand if you do not want to carry this work-around in the official release.