### PR TITLE
#258 Document running as non-superuser on PostgreSQL versions 10 or newer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,14 +203,10 @@ If you want to include only subset of databases, you can use option `--include-d
 
 ### Running as non-superuser
 
-To be able to collect metrics from `pg_stat_activity` and `pg_stat_replication`
-as  non-superuser you have to create functions and views as a superuser, and
-assign permissions separately to those.
-
-In PostgreSQL, views run with the permissions of the user that created them so
-they can act as security barriers. Functions need to be created to share this
-data with the non-superuser. Only creating the views will leave out the most
-important bits of data.
+To be able to collect metrics from `pg_stat*` views as non-superuser in PostgreSQL
+server versions >= 10 you can grant pg_monitor built-in role to the user. If
+you need to monitor older PostgreSQL servers, you will have to create functions
+and views as a superuser, and assign permissions separately to those.
 
 ```sql
 -- To use IF statements, hence to be able to check if the user exists before
@@ -239,9 +235,23 @@ ALTER USER postgres_exporter SET SEARCH_PATH TO postgres_exporter,pg_catalog;
 -- If deploying as non-superuser (for example in AWS RDS), uncomment the GRANT
 -- line below and replace <MASTER_USER> with your root user.
 -- GRANT postgres_exporter TO <MASTER_USER>;
+
+GRANT CONNECT ON DATABASE postgres TO postgres_exporter;
+```
+
+Run following command if you use PostgreSQL versions >= 10
+```sql
+GRANT pg_monitor to postgres_exporter;
+```
+
+Run following SQL commands only if you use PostgreSQL versions older than 10.
+In PostgreSQL, views run with the permissions of the user that created them so
+they can act as security barriers. Functions need to be created to share this
+data with the non-superuser. Only creating the views will leave out the most
+important bits of data.
+```sql
 CREATE SCHEMA IF NOT EXISTS postgres_exporter;
 GRANT USAGE ON SCHEMA postgres_exporter TO postgres_exporter;
-GRANT CONNECT ON DATABASE postgres TO postgres_exporter;
 
 CREATE OR REPLACE FUNCTION get_pg_stat_activity() RETURNS SETOF pg_stat_activity AS
 $$ SELECT * FROM pg_catalog.pg_stat_activity; $$

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ If you want to include only subset of databases, you can use option `--include-d
 ### Running as non-superuser
 
 To be able to collect metrics from `pg_stat*` views as non-superuser in PostgreSQL
-server versions >= 10 you can grant pg_monitor built-in role to the user. If
+server versions >= 10 you can grant the `pg_monitor` or `pg_read_all_stats` [built-in roles](https://www.postgresql.org/docs/current/predefined-roles.html) to the user. If
 you need to monitor older PostgreSQL servers, you will have to create functions
 and views as a superuser, and assign permissions separately to those.
 


### PR DESCRIPTION
Starting from version 10, PostgreSQL includes a built-in role `pg_monitor` meant for use by monitoring tools. This PR adds documentation about granting the role when running postgres_exporter as non-superuser. Fixes #258.