### PR TITLE
Correctly set short_version for major version 10 and up

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -653,9 +653,15 @@ func (e *Exporter) checkMapVersions(ch chan<- prometheus.Metric, server *Server)
 	versionDesc := prometheus.NewDesc(fmt.Sprintf("%s_%s", namespace, staticLabelName),
 		"Version string as reported by postgres", []string{"version", "short_version"}, server.labels)
 
+	var semanticVersionShort = semanticVersion.String()
+	if semanticVersion.GE(semver.MustParse("10.0.0")) {
+		var versionSplit = strings.Split(semanticVersion.String(), ".")
+		semanticVersionShort = versionSplit[0] + "." + versionSplit[1]
+
+	}
 	if !e.disableDefaultMetrics && server.master {
 		ch <- prometheus.MustNewConstMetric(versionDesc,
-			prometheus.UntypedValue, 1, versionString, semanticVersion.String())
+			prometheus.UntypedValue, 1, versionString, semanticVersionShort)
 	}
 	return nil
 }


### PR DESCRIPTION
Before, postgres_exporter reported a full three-digit semver for Postgres
versions in the pg_static metric, padding the version with a extra .0, e.g.
13.3 -> 13.3.0.

Fixes: https://github.com/prometheus-community/postgres_exporter/issues/349