### PR TITLE
Fix typo in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run \
 To build the Docker image:
 
     make promu
-    promu crossbuild -p linux/amd64 -p linux/armv7 -p linux/amd64 -p linux/ppc64le
+    promu crossbuild -p linux/amd64 -p linux/armv7 -p linux/arm64 -p linux/ppc64le
     make docker
 
 This will build the docker image as `prometheuscommunity/postgres_exporter:${branch}`.


### PR DESCRIPTION
Hi,

Using the command in the README.md file:
```
make promu
promu crossbuild -p linux/amd64 -p linux/armv7 -p linux/amd64 -p linux/ppc64le
make docker
```

I git the following error:
```
Error: error building at STEP "COPY .build/${OS}-${ARCH}/postgres_exporter /bin/postgres_exporter": checking on sources under "/var/tmp/libpod_builder074335023/build": copier: stat: "/.build/linux-arm64/postgres_exporter": no such file or directory
make: *** [common-docker-arm64] Error 125
```

After a bit of investigation I found out that the problem was the instructions in the README.md file that duplicate the option ```-p linux/amd64```two times instead of using ```-p linux/arm64```. I fixed it, please review it.