### PR TITLE
Add --strip-settings-suffix flag for #619

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `include-databases`
   A list of databases to only include when autoDiscoverDatabases is enabled.
 
+* `strip-settings-suffix`
+  Whether to strip unit siffixes (i.e. KB) from pg_settings metrics.
+
 * `log.level`
   Set logging level: one of `debug`, `info`, `warn`, `error`.
 

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -43,6 +43,7 @@ var (
 	excludeDatabases       = kingpin.Flag("exclude-databases", "A list of databases to remove when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_EXCLUDE_DATABASES").String()
 	includeDatabases       = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
 	metricPrefix           = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
+	stripSettingsSuffix    = kingpin.Flag("strip-settings-suffix", "Whether to strip unit siffixes (i.e. KB) from pg_settings metrics.").Default("false").Envar("PG_EXPORTER_STRIP_METRICS_SUFFIX").Bool()
 	logger                 = log.NewNopLogger()
 )
 

--- a/cmd/postgres_exporter/pg_setting_test.go
+++ b/cmd/postgres_exporter/pg_setting_test.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	. "gopkg.in/check.v1"
@@ -267,4 +269,32 @@ type fixture struct {
 	n normalised
 	d string
 	v float64
+}
+
+func Test_pgSetting_sanitizeValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		setting *pgSetting
+		want    string
+	}{
+		{
+			name: "RDS Shared Buffers",
+			setting: &pgSetting{
+				name:      "shared_buffers",
+				setting:   "88413056kB",
+				unit:      "8kB",
+				shortDesc: "Sets the number of shared memory buffers used by the server.",
+				vartype:   "integer",
+			},
+			want: "88413056",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setting.stripUnitSuffix()
+			if got := tt.setting.setting; got != tt.want {
+				t.Errorf("sanitizeValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Adds --strip-settings-suffix flag to make the fixes for AWS Aurora in #619 opt in for users. It should be safe for all users, but this code should also be unnecessary if AWS fixes their bug.

Signed-off-by: Joe Adams <github@joeadams.io>