### PR TITLE
postgres_mixin: use native jsonnet

### DIFF
--- a/postgres_mixin/mixin.libsonnet
+++ b/postgres_mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules)[0].groups,
   },
 
   prometheusAlerts+: importRules(importstr 'alerts/alerts.yaml'),


### PR DESCRIPTION
`std.native('parseYaml')` is not part of jsonnet standard library. This PR uses `std.parseYaml` which is part of native jsonnet since version 0.18.0.