### PR TITLE
fix: default value of datasource when no environment variables

### DIFF
--- a/cmd/postgres_exporter/datasource.go
+++ b/cmd/postgres_exporter/datasource.go
@@ -162,7 +162,14 @@ func getDataSources() ([]string, error) {
 		uri = os.Getenv("DATA_SOURCE_URI")
 	}
 
-	dsn = "postgresql://" + ui + "@" + uri
+	if len(uri) != 0 {
+		dsn = "postgresql://"
+		if len(ui) != 0 {
+			dsn += ui + "@"
+		}
+		dsn += uri
+		return []string{dsn}, nil
+	}
 
-	return []string{dsn}, nil
+	return nil, nil
 }


### PR DESCRIPTION
https://github.com/prometheus-community/postgres_exporter/blob/92bdb8755de886b2366de245e559538030ba3668/cmd/postgres_exporter/main.go#L88-L97

default value of datasource when no environment variables
`[postgresql://:@]`

check is always false