### PR TITLE
postgres_mixin/alerts: fix incorrect promql aggregation

### DIFF
--- a/postgres_mixin/alerts/postgres.libsonnet
+++ b/postgres_mixin/alerts/postgres.libsonnet
@@ -61,8 +61,8 @@
               summary: 'PostgreSQL high number of slow on {{ $labels.cluster }} for database {{ $labels.datname }} ',
             },
             expr: |||
-              avg(
-                rate by (datname) (
+              avg by (datname) (
+                rate (
                   pg_stat_activity_max_tx_duration{datname!~"template.*",%(postgresExporterSelector)s}[2m]
                 )
               ) > 2 * 60


### PR DESCRIPTION
Previous query results in an error reported by prometheus:

> Error executing query: invalid parameter "query": 2:18: parse error: unexpected <by> in aggregation

This PR is an attempt to fix this.