### PR TITLE
Fix ERROR: recovery is in progress

### DIFF
--- a/cmd/postgres_exporter/queries.go
+++ b/cmd/postgres_exporter/queries.go
@@ -105,14 +105,14 @@ var queryOverrides = map[string][]OverrideQuery{
 		{
 			semver.MustParseRange(">=9.4.0 <10.0.0"),
 			`
-			SELECT slot_name, database, active, pg_xlog_location_diff(pg_current_xlog_location(), restart_lsn)
+			SELECT slot_name, database, active, (case pg_is_in_recovery() when 'false' then pg_xlog_location_diff(pg_current_xlog_location(), restart_lsn) else 0 end)
 			FROM pg_replication_slots
 			`,
 		},
 		{
 			semver.MustParseRange(">=10.0.0"),
 			`
-			SELECT slot_name, database, active, pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)
+			SELECT slot_name, database, active, (case pg_is_in_recovery() when 'false' then pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) else 0 end)
 			FROM pg_replication_slots
 			`,
 		},


### PR DESCRIPTION
An error occurs while backing up a replica:

postgres=# SELECT slot_name, database, active, pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) FROM pg_replication_slots;
ERROR: recovery is in progress
HINT: WAL control functions cannot be executed during recovery.