### PR TITLE
Improve PostgreSQL replication lag detection

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1,5 +1,5 @@
 pg_replication:
-  query: "SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag"
+  query: "SELECT CASE WHEN NOT pg_is_in_recovery() OR pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag"
   master: true
   metrics:
     - lag:


### PR DESCRIPTION
Improve PostgreSQL replication lag detection
If there is no updates in the database, the lag will not grow.

Signed-off-by: WiT <witphg@gmail.com>