### PR TITLE
Ensure loggableDSN scrubs passwords in different ways

### DIFF
--- a/cmd/postgres_exporter/util.go
+++ b/cmd/postgres_exporter/util.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -212,9 +213,23 @@ func loggableDSN(dsn string) string {
 	if err != nil {
 		return "could not parse DATA_SOURCE_NAME"
 	}
+
+	// If the DSN is not a URL it is expected to be in the `key1=value1 key2=value2` format
+	if pDSN.Scheme == "" {
+		re := regexp.MustCompile(`(\s?password=([^"\s]+|"[^"]+"))`)
+		stripped := re.ReplaceAllString(dsn, " password=PASSWORD_REMOVED")
+		return strings.TrimSpace(stripped)
+	}
+
 	// Blank user info if not nil
 	if pDSN.User != nil {
 		pDSN.User = url.UserPassword(pDSN.User.Username(), "PASSWORD_REMOVED")
+	}
+
+	// If the password is contained in a URL parameter, we should remove it there
+	if q, err := url.ParseQuery(pDSN.RawQuery); err == nil && q.Has("password") {
+		q.Set("password", "PASSWORD_REMOVED")
+		pDSN.RawQuery = q.Encode()
 	}
 
 	return pDSN.String()


### PR DESCRIPTION
The previous implementation of the function was only scrubbing those passwords
that were part of a basic http authentication method, which means it
expected passwords to be provided as part of the URL.

However, the password
may also be specified as a parameter, or when using key-values, it may be
specified as a password=value string.

This commit ensures those passwords will also not be retained, but
removed.

Fixes #643 