### PR TITLE
Update readme to include Postgres 14 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Prometheus exporter for PostgreSQL server metrics.
 
-CI Tested PostgreSQL versions: `9.4`, `9.5`, `9.6`, `10`, `11`, `12`, `13`
+CI Tested PostgreSQL versions: `9.4`, `9.5`, `9.6`, `10`, `11`, `12`, `13`, `14`
 
 ## Quick Start
 This package is available for Docker:


### PR DESCRIPTION
It looks like postgres 14.1 was added to CI here:

https://github.com/prometheus-community/postgres_exporter/commit/fcb2535affa0f97c7a11439c19de6a7ff793e0df

See also: https://github.com/prometheus-community/postgres_exporter/issues/651#issuecomment-1156947591