### PR TITLE
Fix checkpoint_write_time value type

### DIFF
--- a/collector/pg_stat_bgwriter.go
+++ b/collector/pg_stat_bgwriter.go
@@ -122,7 +122,7 @@ func (PGStatBGWriterCollector) Update(ctx context.Context, db *sql.DB, ch chan<-
 
 	var cpt int
 	var cpr int
-	var cpwt int
+	var cpwt float64
 	var cpst int
 	var bcp int
 	var bc int


### PR DESCRIPTION
"Scan error on column index 2, name \"checkpoint_write_time\": converting driver.Value type float64 (\"6.594096e+06\") to a int: invalid syntax #633"

Fixes: https://github.com/prometheus-community/postgres_exporter/issues/633

Signed-off-by: bravosierrasierra <bravosierrasierra@users.noreply.github.com>