### PR TITLE
Fix checkpoint_sync_time value type

### DIFF
--- a/collector/pg_stat_bgwriter.go
+++ b/collector/pg_stat_bgwriter.go
@@ -123,7 +123,7 @@ func (PGStatBGWriterCollector) Update(ctx context.Context, db *sql.DB, ch chan<-
 	var cpt int
 	var cpr int
 	var cpwt float64
-	var cpst int
+	var cpst float64
 	var bcp int
 	var bc int
 	var mwc int


### PR DESCRIPTION
Error:
```sh
sql: Scan error on column index 3, name \"checkpoint_sync_time\": converting driver.Value type float64 (\"1.876469e+06\") to a int: invalid syntax
```

See also:
https://github.com/prometheus-community/postgres_exporter/issues/633
https://github.com/prometheus-community/postgres_exporter/pull/666

Thank you!