### PR TITLE
Capture usename and application_name for pg_stat_activity

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -284,6 +284,8 @@ var builtinMetricMaps = map[string]intermediateMetricMap{
 		map[string]ColumnMapping{
 			"datname":         {LABEL, "Name of this database", nil, nil},
 			"state":           {LABEL, "connection state", nil, semver.MustParseRange(">=9.2.0")},
+			"usename":          {LABEL, "connection usename", nil, nil},
+			"application_name": {LABEL, "connection application_name", nil, nil},
 			"count":           {GAUGE, "number of connections in this state", nil, nil},
 			"max_tx_duration": {GAUGE, "max duration in seconds any active transaction has been running", nil, nil},
 		},

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -282,12 +282,12 @@ var builtinMetricMaps = map[string]intermediateMetricMap{
 	},
 	"pg_stat_activity": {
 		map[string]ColumnMapping{
-			"datname":         {LABEL, "Name of this database", nil, nil},
-			"state":           {LABEL, "connection state", nil, semver.MustParseRange(">=9.2.0")},
+			"datname":          {LABEL, "Name of this database", nil, nil},
+			"state":            {LABEL, "connection state", nil, semver.MustParseRange(">=9.2.0")},
 			"usename":          {LABEL, "connection usename", nil, nil},
 			"application_name": {LABEL, "connection application_name", nil, nil},
-			"count":           {GAUGE, "number of connections in this state", nil, nil},
-			"max_tx_duration": {GAUGE, "max duration in seconds any active transaction has been running", nil, nil},
+			"count":            {GAUGE, "number of connections in this state", nil, nil},
+			"max_tx_duration":  {GAUGE, "max duration in seconds any active transaction has been running", nil, nil},
 		},
 		true,
 		0,

--- a/cmd/postgres_exporter/queries.go
+++ b/cmd/postgres_exporter/queries.go
@@ -137,6 +137,8 @@ var queryOverrides = map[string][]OverrideQuery{
 			SELECT
 				pg_database.datname,
 				tmp.state,
+				tmp2.usename,
+				tmp2.application_name,
 				COALESCE(count,0) as count,
 				COALESCE(max_tx_duration,0) as max_tx_duration
 			FROM
@@ -153,9 +155,11 @@ var queryOverrides = map[string][]OverrideQuery{
 				SELECT
 					datname,
 					state,
+					usename,
+					application_name,
 					count(*) AS count,
 					MAX(EXTRACT(EPOCH FROM now() - xact_start))::float AS max_tx_duration
-				FROM pg_stat_activity GROUP BY datname,state) AS tmp2
+				FROM pg_stat_activity GROUP BY datname,state,usename,application_name) AS tmp2
 				ON tmp.state = tmp2.state AND pg_database.datname = tmp2.datname
 			`,
 		},
@@ -165,9 +169,11 @@ var queryOverrides = map[string][]OverrideQuery{
 			SELECT
 				datname,
 				'unknown' AS state,
+				usename,
+				application_name,
 				COALESCE(count(*),0) AS count,
 				COALESCE(MAX(EXTRACT(EPOCH FROM now() - xact_start))::float,0) AS max_tx_duration
-			FROM pg_stat_activity GROUP BY datname
+			FROM pg_stat_activity GROUP BY datname,usename,application_name
 			`,
 		},
 	},


### PR DESCRIPTION
It is necessary to be able to exclude backups from long-running
transaction alerts, as they are to be expected. With the current
pg_stat_activity metric there is no ability to filter out
specific users or application names.

Resolves #668