### PR TITLE
Fix exclude-databases for collector package

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -484,9 +484,9 @@ func AutoDiscoverDatabases(b bool) ExporterOpt {
 }
 
 // ExcludeDatabases allows to filter out result from AutoDiscoverDatabases
-func ExcludeDatabases(s string) ExporterOpt {
+func ExcludeDatabases(s []string) ExporterOpt {
 	return func(e *Exporter) {
-		e.excludeDatabases = strings.Split(s, ",")
+		e.excludeDatabases = s
 	}
 }
 

--- a/cmd/postgres_exporter/probe.go
+++ b/cmd/postgres_exporter/probe.go
@@ -61,21 +61,9 @@ func handleProbe(logger log.Logger, excludeDatabases []string) http.HandlerFunc 
 
 		// TODO(@sysadmind): Timeout
 
-		// probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		// 	Name: "probe_success",
-		// 	Help: "Displays whether or not the probe was a success",
-		// })
-		// probeDurationGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		// 	Name: "probe_duration_seconds",
-		// 	Help: "Returns how long the probe took to complete in seconds",
-		// })
-
 		tl := log.With(logger, "target", target)
 
-		// start := time.Now()
 		registry := prometheus.NewRegistry()
-		// registry.MustRegister(probeSuccessGauge)
-		// registry.MustRegister(probeDurationGauge)
 
 		opts := []ExporterOpt{
 			DisableDefaultMetrics(*disableDefaultMetrics),
@@ -83,7 +71,7 @@ func handleProbe(logger log.Logger, excludeDatabases []string) http.HandlerFunc 
 			AutoDiscoverDatabases(*autoDiscoverDatabases),
 			WithUserQueriesPath(*queriesPath),
 			WithConstantLabels(*constantLabelsList),
-			ExcludeDatabases(*excludeDatabases),
+			ExcludeDatabases(excludeDatabases),
 			IncludeDatabases(*includeDatabases),
 		}
 

--- a/cmd/postgres_exporter/probe.go
+++ b/cmd/postgres_exporter/probe.go
@@ -85,8 +85,6 @@ func handleProbe(logger log.Logger, excludeDatabases []string) http.HandlerFunc 
 		// Run the probe
 		pc, err := collector.NewProbeCollector(tl, excludeDatabases, registry, dsn)
 		if err != nil {
-			// probeSuccessGauge.Set(0)
-			// probeDurationGauge.Set(time.Since(start).Seconds())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/cmd/postgres_exporter/probe.go
+++ b/cmd/postgres_exporter/probe.go
@@ -16,7 +16,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -26,7 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func handleProbe(logger log.Logger) http.HandlerFunc {
+func handleProbe(logger log.Logger, excludeDatabases []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		conf := c.GetConfig()
@@ -62,21 +61,21 @@ func handleProbe(logger log.Logger) http.HandlerFunc {
 
 		// TODO(@sysadmind): Timeout
 
-		probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "probe_success",
-			Help: "Displays whether or not the probe was a success",
-		})
-		probeDurationGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "probe_duration_seconds",
-			Help: "Returns how long the probe took to complete in seconds",
-		})
+		// probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		// 	Name: "probe_success",
+		// 	Help: "Displays whether or not the probe was a success",
+		// })
+		// probeDurationGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		// 	Name: "probe_duration_seconds",
+		// 	Help: "Returns how long the probe took to complete in seconds",
+		// })
 
 		tl := log.With(logger, "target", target)
 
-		start := time.Now()
+		// start := time.Now()
 		registry := prometheus.NewRegistry()
-		registry.MustRegister(probeSuccessGauge)
-		registry.MustRegister(probeDurationGauge)
+		// registry.MustRegister(probeSuccessGauge)
+		// registry.MustRegister(probeDurationGauge)
 
 		opts := []ExporterOpt{
 			DisableDefaultMetrics(*disableDefaultMetrics),
@@ -96,10 +95,10 @@ func handleProbe(logger log.Logger) http.HandlerFunc {
 		registry.MustRegister(exporter)
 
 		// Run the probe
-		pc, err := collector.NewProbeCollector(tl, registry, dsn)
+		pc, err := collector.NewProbeCollector(tl, excludeDatabases, registry, dsn)
 		if err != nil {
-			probeSuccessGauge.Set(0)
-			probeDurationGauge.Set(time.Since(start).Seconds())
+			// probeSuccessGauge.Set(0)
+			// probeDurationGauge.Set(time.Since(start).Seconds())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -114,10 +113,6 @@ func handleProbe(logger log.Logger) http.HandlerFunc {
 		_ = ctx
 
 		registry.MustRegister(pc)
-
-		duration := time.Since(start).Seconds()
-		probeDurationGauge.Set(duration)
-		probeSuccessGauge.Set(1)
 
 		// TODO check success, etc
 		h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})

--- a/collector/pg_database.go
+++ b/collector/pg_database.go
@@ -26,11 +26,19 @@ func init() {
 }
 
 type PGDatabaseCollector struct {
-	log log.Logger
+	log               log.Logger
+	excludedDatabases []string
 }
 
-func NewPGDatabaseCollector(logger log.Logger) (Collector, error) {
-	return &PGDatabaseCollector{log: logger}, nil
+func NewPGDatabaseCollector(config collectorConfig) (Collector, error) {
+	exclude := config.excludeDatabases
+	if exclude == nil {
+		exclude = []string{}
+	}
+	return &PGDatabaseCollector{
+		log:               config.logger,
+		excludedDatabases: exclude,
+	}, nil
 }
 
 var pgDatabase = map[string]*prometheus.Desc{
@@ -41,20 +49,49 @@ var pgDatabase = map[string]*prometheus.Desc{
 	),
 }
 
-func (PGDatabaseCollector) Update(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+// Update implements Collector and exposes database size.
+// It is called by the Prometheus registry when collecting metrics.
+// The list of databases is retrieved from pg_database and filtered
+// by the excludeDatabase config parameter. The tradeoff here is that
+// we have to query the list of databases and then query the size of
+// each database individually. This is because we can't filter the
+// list of databases in the query because the list of excluded
+// databases is dynamic.
+func (c PGDatabaseCollector) Update(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	// Query the list of databases
 	rows, err := db.QueryContext(ctx,
 		`SELECT pg_database.datname
-		,pg_database_size(pg_database.datname)
-		FROM pg_database;`)
+		FROM pg_database;
+		`,
+	)
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 
+	var databases []string
+
 	for rows.Next() {
 		var datname string
+		if err := rows.Scan(&datname); err != nil {
+			return err
+		}
+
+		// Ignore excluded databases
+		// Filtering is done here instead of in the query to avoid
+		// a complicated NOT IN query with a variable number of parameters
+		if sliceContains(c.excludedDatabases, datname) {
+			continue
+		}
+
+		databases = append(databases, datname)
+	}
+
+	// Query the size of the databases
+	for _, datname := range databases {
 		var size int64
-		if err := rows.Scan(&datname, &size); err != nil {
+		err = db.QueryRowContext(ctx, "SELECT pg_database_size($1)", datname).Scan(&size)
+		if err != nil {
 			return err
 		}
 
@@ -67,4 +104,13 @@ func (PGDatabaseCollector) Update(ctx context.Context, db *sql.DB, ch chan<- pro
 		return err
 	}
 	return nil
+}
+
+func sliceContains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }

--- a/collector/pg_stat_bgwriter.go
+++ b/collector/pg_stat_bgwriter.go
@@ -18,7 +18,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -29,7 +28,7 @@ func init() {
 type PGStatBGWriterCollector struct {
 }
 
-func NewPGStatBGWriterCollector(logger log.Logger) (Collector, error) {
+func NewPGStatBGWriterCollector(collectorConfig) (Collector, error) {
 	return &PGStatBGWriterCollector{}, nil
 }
 

--- a/collector/replication_slots.go
+++ b/collector/replication_slots.go
@@ -29,8 +29,8 @@ type PGReplicationSlotCollector struct {
 	log log.Logger
 }
 
-func NewPGReplicationSlotCollector(logger log.Logger) (Collector, error) {
-	return &PGReplicationSlotCollector{log: logger}, nil
+func NewPGReplicationSlotCollector(config collectorConfig) (Collector, error) {
+	return &PGReplicationSlotCollector{log: config.logger}, nil
 }
 
 var pgReplicationSlot = map[string]*prometheus.Desc{


### PR DESCRIPTION
The pg_database collector was not respecting the --exclude-databases flag and causing problems where databases were not accessible. This now respects the list of databases to exclude.

- Adjusts the Collector create func to take a config struct instead of a logger. This allows more changes like this in the future. I figured we would need to do this at some point but I wasn't sure if we could hold off.
- Split the database size collection to a separate query when database is not excluded.
- Comment some probe code that was not useful/accurate

Signed-off-by: Joe Adams <github@joeadams.io>