### PR TITLE
Close DB connection after probe completes.

### DIFF
--- a/cmd/postgres_exporter/probe.go
+++ b/cmd/postgres_exporter/probe.go
@@ -104,6 +104,9 @@ func handleProbe(logger log.Logger) http.HandlerFunc {
 			return
 		}
 
+		// Cleanup underlying connections to prevent connection leaks
+		defer pc.Close()
+
 		// TODO(@sysadmind): Remove the registry.MustRegister() call below and instead handle the collection here. That will allow
 		// for the passing of context, handling of timeouts, and more control over the collection.
 		// The current NewProbeCollector() implementation relies on the MustNewConstMetric() call to create the metrics which is not

--- a/collector/probe.go
+++ b/collector/probe.go
@@ -83,3 +83,7 @@ func (pc *ProbeCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	wg.Wait()
 }
+
+func (pc *ProbeCollector) Close() error {
+	return pc.db.Close()
+}


### PR DESCRIPTION
Currently each probe creates a new DB connection which is never closed.  This fix closes the connection upon the completion of a probe.  An alternative solution would be to inject a DB object into the handleProbe handler, but that would be a larger scope change.

Tested locally and scrapes correctly without increasing the number of connections in Postgres.  

edit: since opening the PR I have been running this in a dev environment and scrapes are working as expected and connection level is staying stable.

Will fix https://github.com/prometheus-community/postgres_exporter/issues/727

Signed-off-by: Kurtis Bass <kurtis.bass@hinge.co>