### PR TITLE
New unit value 64kB

### DIFF
--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -129,7 +129,7 @@ func (s *pgSetting) normaliseUnit() (val float64, unit string, err error) {
 		return
 	case "ms", "s", "min", "h", "d":
 		unit = "seconds"
-	case "B", "kB", "MB", "GB", "TB", "4kB", "8kB", "16kB", "32kB", "16MB", "32MB", "64MB":
+	case "B", "kB", "MB", "GB", "TB", "4kB", "8kB", "16kB", "32kB", "64kB", "16MB", "32MB", "64MB":
 		unit = "bytes"
 	default:
 		err = fmt.Errorf("Unknown unit for runtime variable: %q", s.unit)
@@ -166,6 +166,8 @@ func (s *pgSetting) normaliseUnit() (val float64, unit string, err error) {
 		val *= math.Pow(2, 14)
 	case "32kB":
 		val *= math.Pow(2, 15)
+	case "64kB":
+		val *= math.Pow(2, 16)
 	case "16MB":
 		val *= math.Pow(2, 24)
 	case "32MB":


### PR DESCRIPTION
For Postgres 15  database, exporter panic with error:
`panic: Unknown unit for runtime variable: "64kB"

goroutine 25 [running]:
main.(*pgSetting).metric(0xc0005790e0, 0xc0003b9c50?)
	/app/cmd/postgres_exporter/pg_setting.go:87 +0x2fc
main.querySettings(0x0?, 0xc0001b4fd0)
	/app/cmd/postgres_exporter/pg_setting.go:56 +0x29e
main.(*Server).Scrape(0xc0001b4fd0, 0xc000026011?, 0xd0?)
	/app/cmd/postgres_exporter/server.go:121 +0xd7
main.(*Exporter).scrapeDSN(0xc0001bc0c0, 0xc0000ce764?, {0xc000026011, 0x55})
	/app/cmd/postgres_exporter/datasource.go:116 +0x1cd
main.(*Exporter).scrape(0xc0001bc0c0, 0xc0000ce660?)
	/app/cmd/postgres_exporter/postgres_exporter.go:711 +0x235
main.(*Exporter).Collect(0xc0001bc0c0, 0xc0000ce760?)
	/app/cmd/postgres_exporter/postgres_exporter.go:600 +0x27
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/go/pkg/mod/github.com/prometheus/client_golang@v1.12.2/prometheus/registry.go:448 +0x11a
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/pkg/mod/github.com/prometheus/client_golang@v1.12.2/prometheus/registry.go:538 +0xb0b
`
So, MR only add a new unit - 64kB