### PR TITLE
Remove QueryID to fix #549

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -148,7 +148,7 @@ pg_statio_user_tables:
 
 # WARNING: This set of metrics can be very expensive on a busy server as every unique query executed will create an additional time series
 pg_stat_statements:
-  query: "SELECT t2.rolname, t3.datname, queryid, calls, total_time / 1000 as total_time_seconds, min_time / 1000 as min_time_seconds, max_time / 1000 as max_time_seconds, mean_time / 1000 as mean_time_seconds, stddev_time / 1000 as stddev_time_seconds, rows, shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, temp_blks_written, blk_read_time / 1000 as blk_read_time_seconds, blk_write_time / 1000 as blk_write_time_seconds FROM pg_stat_statements t1 JOIN pg_roles t2 ON (t1.userid=t2.oid) JOIN pg_database t3 ON (t1.dbid=t3.oid) WHERE t2.rolname != 'rdsadmin'"
+  query: "SELECT t2.rolname, t3.datname, calls, total_time / 1000 as total_time_seconds, min_time / 1000 as min_time_seconds, max_time / 1000 as max_time_seconds, mean_time / 1000 as mean_time_seconds, stddev_time / 1000 as stddev_time_seconds, rows, shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, temp_blks_written, blk_read_time / 1000 as blk_read_time_seconds, blk_write_time / 1000 as blk_write_time_seconds FROM pg_stat_statements t1 JOIN pg_roles t2 ON (t1.userid=t2.oid) JOIN pg_database t3 ON (t1.dbid=t3.oid) WHERE t2.rolname != 'rdsadmin'"
   master: true
   metrics:
     - rolname:
@@ -157,9 +157,6 @@ pg_stat_statements:
     - datname:
         usage: "LABEL"
         description: "Name of database"
-    - queryid:
-        usage: "LABEL"
-        description: "Query ID"
     - calls:
         usage: "COUNTER"
         description: "Number of times executed"


### PR DESCRIPTION
If users follow the RDS documentation included in this repo, they will use this SQL yaml and encounter a cardinality explosion, because 19 separate metrics are stored for each new query that gets performed. Removed `queryid` to fix #549.