### PR TITLE
Automatically set GOMAXPROCS based on CPU quota to avoid throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ auth_modules:
 To build the Docker image:
 
     make promu
-    promu crossbuild -p linux/amd64 -p linux/armv7 -p linux/amd64 -p linux/ppc64le
+    promu crossbuild -p linux/amd64 -p linux/armv7 -p linux/arm64 -p linux/ppc64le
     make docker
 
 This will build the docker image as `prometheuscommunity/postgres_exporter:${branch}`.

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	excludedDatabases := strings.Split(*excludeDatabases, ",")
-	logger.Log("msg", "Excluded databases", "databases", fmt.Sprintf("%v", excludedDatabases))
+	level.Info(logger).Log("msg", "Excluded databases", "databases", fmt.Sprintf("%v", excludedDatabases))
 
 	opts := []ExporterOpt{
 		DisableDefaultMetrics(*disableDefaultMetrics),

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/exporter-toolkit v0.8.2
+	go.uber.org/automaxprocs v1.5.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
 github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
 github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
@@ -53,6 +54,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+go.uber.org/automaxprocs v1.5.1 h1:e1YG66Lrk73dn4qhg8WFSvhF0JuFQF0ERIp4rpuV8Qk=
+go.uber.org/automaxprocs v1.5.1/go.mod h1:BF4eumQw0P9GtnuxxovUd06vwm1o18oMzFtK66vU6XU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=


### PR DESCRIPTION
Hello,

In Go, maximum parallelism can be controlled via the GOMAXPROCS environment variable. If not set, this setting defaults to the number of CPUs available on the machine even if the program is running in a container with CPU quota: https://github.com/golang/go/issues/33803.

Due to the functioning of the CFS scheduler in Linux kernel, this can lead to CPU throttling even if CPU usage is well below the quota (here the quota is a full CPU, 1000 millicores):

**CPU usage in millicores**

![CPU usage in millicores](https://user-images.githubusercontent.com/8511577/223788665-4c3214e8-fae8-4c1b-9c5d-f6605e64aea2.png)

**CPU throttling in percentage**

![CPU throttling in percentage](https://user-images.githubusercontent.com/8511577/223788817-706c4eb5-6d29-4ba4-b047-26e66207c52e.png)

To solve this problem, Uber maintains a package to automatically set GOMAXPROCS based on CPU quota: https://github.com/uber-go/automaxprocs. When using it, the situation greatly improves (still with the same CPU quota as above):

**CPU usage in millicores**

![CPU usage in millicores](https://user-images.githubusercontent.com/8511577/223791587-438883b6-5185-4a3c-a070-0a32c3509dfc.png)

**CPU throttling in percentage**

![CPU throttling in percentage](https://user-images.githubusercontent.com/8511577/223790729-c3e80cce-da42-4228-ba35-235a2bae86bc.png)

This PR proposes to use the automaxprocs package from Uber.