### PR TITLE
Fix pg_setting different help values

### DIFF
--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -70,7 +70,7 @@ func (s *pgSetting) metric(labels prometheus.Labels) prometheus.Metric {
 		err       error
 		name      = strings.Replace(s.name, ".", "_", -1)
 		unit      = s.unit // nolint: ineffassign
-		shortDesc = s.shortDesc
+		shortDesc = fmt.Sprintf("Server Parameter: %s", s.name)
 		subsystem = "settings"
 		val       float64
 	)

--- a/cmd/postgres_exporter/pg_setting_test.go
+++ b/cmd/postgres_exporter/pg_setting_test.go
@@ -40,7 +40,7 @@ var fixtures = []fixture{
 			unit: "seconds",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_seconds_fixture_metric_seconds", help: "Foo foo foo [Units converted to seconds.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_seconds_fixture_metric_seconds", help: "Server Parameter: seconds_fixture_metric [Units converted to seconds.]", constLabels: {}, variableLabels: []}`,
 		v: 5,
 	},
 	{
@@ -56,7 +56,7 @@ var fixtures = []fixture{
 			unit: "seconds",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_milliseconds_fixture_metric_seconds", help: "Foo foo foo [Units converted to seconds.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_milliseconds_fixture_metric_seconds", help: "Server Parameter: milliseconds_fixture_metric [Units converted to seconds.]", constLabels: {}, variableLabels: []}`,
 		v: 5,
 	},
 	{
@@ -72,7 +72,7 @@ var fixtures = []fixture{
 			unit: "bytes",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_eight_kb_fixture_metric_bytes", help: "Foo foo foo [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_eight_kb_fixture_metric_bytes", help: "Server Parameter: eight_kb_fixture_metric [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
 		v: 139264,
 	},
 	{
@@ -88,7 +88,7 @@ var fixtures = []fixture{
 			unit: "bytes",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_16_kb_real_fixture_metric_bytes", help: "Foo foo foo [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_16_kb_real_fixture_metric_bytes", help: "Server Parameter: 16_kb_real_fixture_metric [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
 		v: 49152,
 	},
 	{
@@ -104,7 +104,7 @@ var fixtures = []fixture{
 			unit: "bytes",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_16_mb_real_fixture_metric_bytes", help: "Foo foo foo [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_16_mb_real_fixture_metric_bytes", help: "Server Parameter: 16_mb_real_fixture_metric [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
 		v: 5.0331648e+07,
 	},
 	{
@@ -120,7 +120,7 @@ var fixtures = []fixture{
 			unit: "bytes",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_32_mb_real_fixture_metric_bytes", help: "Foo foo foo [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_32_mb_real_fixture_metric_bytes", help: "Server Parameter: 32_mb_real_fixture_metric [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
 		v: 1.00663296e+08,
 	},
 	{
@@ -136,7 +136,7 @@ var fixtures = []fixture{
 			unit: "bytes",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_64_mb_real_fixture_metric_bytes", help: "Foo foo foo [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_64_mb_real_fixture_metric_bytes", help: "Server Parameter: 64_mb_real_fixture_metric [Units converted to bytes.]", constLabels: {}, variableLabels: []}`,
 		v: 2.01326592e+08,
 	},
 	{
@@ -152,7 +152,7 @@ var fixtures = []fixture{
 			unit: "",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_bool_on_fixture_metric", help: "Foo foo foo", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_bool_on_fixture_metric", help: "Server Parameter: bool_on_fixture_metric", constLabels: {}, variableLabels: []}`,
 		v: 1,
 	},
 	{
@@ -168,7 +168,7 @@ var fixtures = []fixture{
 			unit: "",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_bool_off_fixture_metric", help: "Foo foo foo", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_bool_off_fixture_metric", help: "Server Parameter: bool_off_fixture_metric", constLabels: {}, variableLabels: []}`,
 		v: 0,
 	},
 	{
@@ -184,7 +184,7 @@ var fixtures = []fixture{
 			unit: "seconds",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_special_minus_one_value_seconds", help: "foo foo foo [Units converted to seconds.]", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_special_minus_one_value_seconds", help: "Server Parameter: special_minus_one_value [Units converted to seconds.]", constLabels: {}, variableLabels: []}`,
 		v: -1,
 	},
 	{
@@ -200,7 +200,7 @@ var fixtures = []fixture{
 			unit: "",
 			err:  "",
 		},
-		d: `Desc{fqName: "pg_settings_rds_rds_superuser_reserved_connections", help: "Sets the number of connection slots reserved for rds_superusers.", constLabels: {}, variableLabels: []}`,
+		d: `Desc{fqName: "pg_settings_rds_rds_superuser_reserved_connections", help: "Server Parameter: rds.rds_superuser_reserved_connections", constLabels: {}, variableLabels: []}`,
 		v: 2,
 	},
 	{


### PR DESCRIPTION
pg_settings metrics have different short descriptions in different pg versions #770

Similar to #598