### PR TITLE
Upgrading go version into Go 1.19.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.17
+go 1.19.6
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
The Go 1.17 version was deprecated [7 months ago](https://endoflife.date/go). Go 1.19.6 [fixed](https://endoflife.date/go) [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723).