### PR TITLE
Adjust log level for collector startup

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	if err := c.ReloadConfig(*configFile, logger); err != nil {
 		// This is not fatal, but it means that auth must be provided for every dsn.
-		level.Error(logger).Log("msg", "Error loading config", "err", err)
+		level.Warn(logger).Log("msg", "Error loading config", "err", err)
 	}
 
 	dsns, err := getDataSources()
@@ -127,7 +127,7 @@ func main() {
 		[]string{},
 	)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to create PostgresCollector", "err", err.Error())
+		level.Warn(logger).Log("msg", "Failed to create PostgresCollector", "err", err.Error())
 	} else {
 		prometheus.MustRegister(pe)
 	}


### PR DESCRIPTION
Since we support both multi-target and typical direct scrapes, either of these can fail and it is no longer an error.

Fixes #779
