### PR TITLE
Supports alternate postgres:// prefix in URLs

### DIFF
--- a/cmd/postgres_exporter/datasource.go
+++ b/cmd/postgres_exporter/datasource.go
@@ -35,7 +35,7 @@ func (e *Exporter) discoverDatabaseDSNs() []string {
 		var dsnURI *url.URL
 		var dsnConnstring string
 
-		if strings.HasPrefix(dsn, "postgresql://") {
+		if strings.HasPrefix(dsn, "postgresql://") || strings.HasPrefix(dsn, "postgres://") {
 			var err error
 			dsnURI, err = url.Parse(dsn)
 			if err != nil {

--- a/config/dsn.go
+++ b/config/dsn.go
@@ -65,7 +65,7 @@ func (d DSN) GetConnectionString() string {
 // dsnFromString parses a connection string into a dsn. It will attempt to parse the string as
 // a URL and as a set of key=value pairs. If both attempts fail, dsnFromString will return an error.
 func dsnFromString(in string) (DSN, error) {
-	if strings.HasPrefix(in, "postgresql://") {
+	if strings.HasPrefix(in, "postgresql://") || strings.HasPrefix(in, "postgres://") {
 		return dsnFromURL(in)
 	}
 

--- a/config/dsn_test.go
+++ b/config/dsn_test.go
@@ -187,6 +187,19 @@ func Test_dsnFromString(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:  "Alternative URL prefix",
+			input: "postgres://user:s3cret@host.example.com:5432/tsdb?user=postgres",
+			want: DSN{
+				scheme:   "postgres",
+				host:     "host.example.com:5432",
+				path:     "/tsdb",
+				query:    url.Values{},
+				username: "user",
+				password: "s3cret",
+			},
+			wantErr: false,
+		},
+		{
 			name:  "URL with user and password in query string",
 			input: "postgresql://host.example.com:5432/tsdb?user=postgres&password=s3cr3t",
 			want: DSN{


### PR DESCRIPTION
Adds support for the alternate postgres:// prefix in URLs. It's maybe not the cleanest approach, but works.  Hoping I can either get some pointers on a more appropriate patch, or that we could use this in the interim to unblock this use-case.

Fixes: #660 