### PR TITLE
Deprecate additional database features

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `disable-settings-metrics`
   Use the flag if you don't want to scrape `pg_settings`.  Default is `false`.
 
-* `auto-discover-databases`
+* `auto-discover-databases` (DEPRECATED)
   Whether to discover the databases on a server dynamically.  Default is `false`.
 
 * `extend.query-path` (DEPRECATED)
@@ -113,16 +113,16 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
   Do not run - print the internal representation of the metric maps. Useful when debugging a custom
   queries file.
 
-* `constantLabels`
+* `constantLabels` (DEPRECATED)
   Labels to set in all metrics. A list of `label=value` pairs, separated by commas.
 
 * `version`
   Show application version.
 
-* `exclude-databases`
+* `exclude-databases` (DEPRECATED)
   A list of databases to remove when autoDiscoverDatabases is enabled.
 
-* `include-databases`
+* `include-databases` (DEPRECATED)
   A list of databases to only include when autoDiscoverDatabases is enabled.
 
 * `log.level`
@@ -170,20 +170,20 @@ The following environment variables configure the exporter:
 * `PG_EXPORTER_DISABLE_SETTINGS_METRICS`
   Use the flag if you don't want to scrape `pg_settings`. Value can be `true` or `false`. Default is `false`.
 
-* `PG_EXPORTER_AUTO_DISCOVER_DATABASES`
+* `PG_EXPORTER_AUTO_DISCOVER_DATABASES` (DEPRECATED)
   Whether to discover the databases on a server dynamically. Value can be `true` or `false`. Default is `false`.
 
 * `PG_EXPORTER_EXTEND_QUERY_PATH`
   Path to a YAML file containing custom queries to run. Check out [`queries.yaml`](queries.yaml)
   for examples of the format.
 
-* `PG_EXPORTER_CONSTANT_LABELS`
+* `PG_EXPORTER_CONSTANT_LABELS` (DEPRECATED)
   Labels to set in all metrics. A list of `label=value` pairs, separated by commas.
 
-* `PG_EXPORTER_EXCLUDE_DATABASES`
+* `PG_EXPORTER_EXCLUDE_DATABASES` (DEPRECATED)
   A comma-separated list of databases to remove when autoDiscoverDatabases is enabled. Default is empty string.
 
-* `PG_EXPORTER_INCLUDE_DATABASES`
+* `PG_EXPORTER_INCLUDE_DATABASES` (DEPRECATED)
   A comma-separated list of databases to only include when autoDiscoverDatabases is enabled. Default is empty string,
   means allow all.
 
@@ -235,7 +235,7 @@ or variants of postgres (e.g. Greenplum), you can disable the default metrics wi
 flag. This removes all built-in metrics, and uses only metrics defined by queries in the `queries.yaml` file you supply
 (so you must supply one, otherwise the exporter will return nothing but internal statuses and not your database).
 
-### Automatically discover databases
+### Automatically discover databases (DEPRECATED)
 To scrape metrics from all databases on a database server, the database DSN's can be dynamically discovered via the
 `--auto-discover-databases` flag. When true, `SELECT datname FROM pg_database WHERE datallowconn = true AND datistemplate = false and datname != current_database()` is run for all configured DSN's. From the
 result a new set of DSN's is created for which the metrics are scraped.

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -43,12 +43,12 @@ var (
 	metricsPath            = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").Envar("PG_EXPORTER_WEB_TELEMETRY_PATH").String()
 	disableDefaultMetrics  = kingpin.Flag("disable-default-metrics", "Do not include default metrics.").Default("false").Envar("PG_EXPORTER_DISABLE_DEFAULT_METRICS").Bool()
 	disableSettingsMetrics = kingpin.Flag("disable-settings-metrics", "Do not include pg_settings metrics.").Default("false").Envar("PG_EXPORTER_DISABLE_SETTINGS_METRICS").Bool()
-	autoDiscoverDatabases  = kingpin.Flag("auto-discover-databases", "Whether to discover the databases on a server dynamically.").Default("false").Envar("PG_EXPORTER_AUTO_DISCOVER_DATABASES").Bool()
+	autoDiscoverDatabases  = kingpin.Flag("auto-discover-databases", "Whether to discover the databases on a server dynamically. (DEPRECATED)").Default("false").Envar("PG_EXPORTER_AUTO_DISCOVER_DATABASES").Bool()
 	queriesPath            = kingpin.Flag("extend.query-path", "Path to custom queries to run. (DEPRECATED)").Default("").Envar("PG_EXPORTER_EXTEND_QUERY_PATH").String()
 	onlyDumpMaps           = kingpin.Flag("dumpmaps", "Do not run, simply dump the maps.").Bool()
-	constantLabelsList     = kingpin.Flag("constantLabels", "A list of label=value separated by comma(,).").Default("").Envar("PG_EXPORTER_CONSTANT_LABELS").String()
-	excludeDatabases       = kingpin.Flag("exclude-databases", "A list of databases to remove when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_EXCLUDE_DATABASES").String()
-	includeDatabases       = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
+	constantLabelsList     = kingpin.Flag("constantLabels", "A list of label=value separated by comma(,). (DEPRECATED)").Default("").Envar("PG_EXPORTER_CONSTANT_LABELS").String()
+	excludeDatabases       = kingpin.Flag("exclude-databases", "A list of databases to remove when autoDiscoverDatabases is enabled (DEPRECATED)").Default("").Envar("PG_EXPORTER_EXCLUDE_DATABASES").String()
+	includeDatabases       = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled (DEPRECATED)").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
 	metricPrefix           = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
 	logger                 = log.NewNopLogger()
 )
@@ -97,6 +97,14 @@ func main() {
 
 	if *queriesPath != "" {
 		level.Warn(logger).Log("msg", "The extend queries.yaml config is DEPRECATD", "file", *queriesPath)
+	}
+
+	if *autoDiscoverDatabases || *excludeDatabases != "" || *includeDatabases != "" {
+		level.Warn(logger).Log("msg", "Scraping additional databases via auto discovery is DEPRECATD")
+	}
+
+	if *constantLabelsList != "" {
+		level.Warn(logger).Log("msg", "Constant lables on all metrics is DEPRECATD")
 	}
 
 	opts := []ExporterOpt{


### PR DESCRIPTION
Now that we have deprecated extended queries we can deprecate related database features.
* Deprecate flags/functions around auto discover databases.
* Deprecate flags/functions for additional constant labels.