### PR TITLE
Fixed replication pgReplicationSlotQuery execution for replica

### DIFF
--- a/collector/pg_replication_slot.go
+++ b/collector/pg_replication_slot.go
@@ -66,11 +66,14 @@ var (
 
 	pgReplicationSlotQuery = `SELECT
 		slot_name,
-		pg_current_wal_lsn() - '0/0' AS current_wal_lsn,
-		coalesce(confirmed_flush_lsn, '0/0') - '0/0',
+		CASE WHEN pg_is_in_recovery() THEN 
+		    pg_last_wal_receive_lsn() - '0/0'
+		ELSE 
+		    pg_current_wal_lsn() - '0/0' 
+		END AS current_wal_lsn,
+		COALESCE(confirmed_flush_lsn, '0/0') - '0/0',
 		active
-	FROM
-		pg_replication_slots;`
+	FROM pg_replication_slots;`
 )
 
 func (PGReplicationSlotCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {


### PR DESCRIPTION
Fixed case when replica has replication slot and we cannot perform some wal control function during pg recovering (replication itself). 

Wrong query:
```
SELECT
	slot_name,
	pg_current_wal_lsn() - '0/0' AS current_wal_lsn,
	coalesce(confirmed_flush_lsn, '0/0') - '0/0',
	active
FROM
	pg_replication_slots;
```

<img width="533" alt="image" src="https://github.com/prometheus-community/postgres_exporter/assets/74241416/9c2fa8be-35be-4e70-b04f-5363168d80c5">

Fixed query:
```
SELECT
    slot_name,
    CASE
        WHEN PG_IS_IN_RECOVERY() THEN pg_last_wal_receive_lsn() - '0/0'
        ELSE pg_current_wal_lsn() - '0/0' END AS current_wal_lsn,
    COALESCE(confirmed_flush_lsn, '0/0') - '0/0',
    active
FROM pg_replication_slots;
```

<img width="592" alt="image" src="https://github.com/prometheus-community/postgres_exporter/assets/74241416/28f9ea37-41f1-4737-9046-9c3e6f8b76d3">


