### PR TITLE
Unpack postgres arrays for process idle times correctly

### DIFF
--- a/collector/pg_process_idle.go
+++ b/collector/pg_process_idle.go
@@ -83,7 +83,7 @@ func (PGProcessIdleCollector) Update(ctx context.Context, instance *instance, ch
 			GROUP BY 1, 2, 3;`)
 
 	var applicationName sql.NullString
-	var secondsSum sql.NullInt64
+	var secondsSum sql.NullFloat64
 	var secondsCount sql.NullInt64
 	var seconds []float64
 	var secondsBucket []int64
@@ -112,7 +112,7 @@ func (PGProcessIdleCollector) Update(ctx context.Context, instance *instance, ch
 	}
 	secondsSumMetric := 0.0
 	if secondsSum.Valid {
-		secondsSumMetric = float64(secondsSum.Int64)
+		secondsSumMetric = secondsSum.Float64
 	}
 	ch <- prometheus.MustNewConstHistogram(
 		pgProcessIdleSeconds,


### PR DESCRIPTION
The previous code just errored calling `Scan` on the row as the arrays are returned as strings that need to be decoded with `pq.Array`.