### PR TITLE
Deprecate --disable-default-metrics and improve deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `web.telemetry-path`
   Path under which to expose metrics. Default is `/metrics`.
 
-* `disable-default-metrics`
+* `disable-default-metrics` (DEPRECATED)
   Use only metrics supplied from `queries.yaml` via `--extend.query-path`.  Default is `false`.
 
 * `disable-settings-metrics`
@@ -189,7 +189,7 @@ The following environment variables configure the exporter:
 * `PG_EXPORTER_WEB_TELEMETRY_PATH`
   Path under which to expose metrics. Default is `/metrics`.
 
-* `PG_EXPORTER_DISABLE_DEFAULT_METRICS`
+* `PG_EXPORTER_DISABLE_DEFAULT_METRICS` (DEPRECATED)
   Use only metrics supplied from `queries.yaml`. Value can be `true` or `false`. Default is `false`.
 
 * `PG_EXPORTER_DISABLE_SETTINGS_METRICS`
@@ -198,7 +198,7 @@ The following environment variables configure the exporter:
 * `PG_EXPORTER_AUTO_DISCOVER_DATABASES` (DEPRECATED)
   Whether to discover the databases on a server dynamically. Value can be `true` or `false`. Default is `false`.
 
-* `PG_EXPORTER_EXTEND_QUERY_PATH`
+* `PG_EXPORTER_EXTEND_QUERY_PATH` (DEPRECATED)
   Path to a YAML file containing custom queries to run. Check out [`queries.yaml`](queries.yaml)
   for examples of the format.
 
@@ -254,7 +254,7 @@ This feature is deprecated in favor of built-in collector functions. For generic
 The -extend.query-path command-line argument specifies a YAML file containing additional queries to run.
 Some examples are provided in [queries.yaml](queries.yaml).
 
-### Disabling default metrics
+### Disabling default metrics (DEPRECATED)
 To work with non-officially-supported postgres versions (e.g. 8.2.15),
 or variants of postgres (e.g. Greenplum), you can disable the default metrics with the `--disable-default-metrics`
 flag. This removes all built-in metrics, and uses only metrics defined by queries in the `queries.yaml` file you supply

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -41,7 +41,7 @@ var (
 	configFile             = kingpin.Flag("config.file", "Postgres exporter configuration file.").Default("postgres_exporter.yml").String()
 	webConfig              = kingpinflag.AddFlags(kingpin.CommandLine, ":9187")
 	metricsPath            = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").Envar("PG_EXPORTER_WEB_TELEMETRY_PATH").String()
-	disableDefaultMetrics  = kingpin.Flag("disable-default-metrics", "Do not include default metrics.").Default("false").Envar("PG_EXPORTER_DISABLE_DEFAULT_METRICS").Bool()
+	disableDefaultMetrics  = kingpin.Flag("disable-default-metrics", "Do not include default metrics. (DEPRECATED)").Default("false").Envar("PG_EXPORTER_DISABLE_DEFAULT_METRICS").Bool()
 	disableSettingsMetrics = kingpin.Flag("disable-settings-metrics", "Do not include pg_settings metrics.").Default("false").Envar("PG_EXPORTER_DISABLE_SETTINGS_METRICS").Bool()
 	autoDiscoverDatabases  = kingpin.Flag("auto-discover-databases", "Whether to discover the databases on a server dynamically. (DEPRECATED)").Default("false").Envar("PG_EXPORTER_AUTO_DISCOVER_DATABASES").Bool()
 	queriesPath            = kingpin.Flag("extend.query-path", "Path to custom queries to run. (DEPRECATED)").Default("").Envar("PG_EXPORTER_EXTEND_QUERY_PATH").String()

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -604,7 +604,7 @@ func (e *Exporter) checkMapVersions(ch chan<- prometheus.Metric, server *Server)
 		return fmt.Errorf("Error fetching version string on %q: %v", server, err)
 	}
 
-	if !e.disableDefaultMetrics && semanticVersion.LT(lowestSupportedVersion) {
+	if semanticVersion.LT(lowestSupportedVersion) {
 		level.Warn(logger).Log("msg", "PostgreSQL version is lower than our lowest supported version", "server", server, "version", semanticVersion, "lowest_supported_version", lowestSupportedVersion)
 	}
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -1,2 +1,2 @@
-# Adding queries to this file is deprecated
-# Example queries have been transformed into collectors.
+# Adding queries to this file is deprecated. Existing queries have been transformed into built-in collectors.
+# The use case where custom queries are generating metrics is better served by the https://github.com/burningalchemist/sql_exporter project.


### PR DESCRIPTION
--disable-default-metrics was used to disable all built in collectors and only run queries from the queries.yaml file which is no longer supported. Improver verbiage in queries.yaml file pointing to replacement collector for custom queries.