### PR TITLE
added decimal point truncate to postmaster start time query

### DIFF
--- a/collector/pg_postmaster.go
+++ b/collector/pg_postmaster.go
@@ -44,7 +44,7 @@ var (
 		[]string{}, nil,
 	)
 
-	pgPostmasterQuery = "SELECT extract(epoch from pg_postmaster_start_time) from pg_postmaster_start_time();"
+	pgPostmasterQuery = "SELECT CAST(extract(epoch from pg_postmaster_start_time()) AS INTEGER) as start_time;" //truncates the decimal part
 )
 
 func (c *PGPostmasterCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {


### PR DESCRIPTION
```
postgres=# SELECT CAST(extract(epoch from pg_postmaster_start_time()) AS INTEGER) as start_time;
 start_time 
------------
 1667939963
(1 row)

postgres=# SELECT extract(epoch from pg_postmaster_start_time()) as start_time;
    start_time     
-------------------
 1667939963.007028
(1 row)
```

the current query results in this error spam:

`ts=2023-07-07T15:35:20.847Z caller=collector.go:190 level=error msg="collector failed" name=postmaster duration_seconds=0.016613707 err="sql: Scan error on column index 0, name \"pg_postmaster_start_time\": converting driver.Value type time.Time (\"2022-11-08 21:39:23.007028 +0100 CET\") to a float64: invalid syntax"`
we probably dont need to use float64 with this change, but i didn't want to make a bigger mess for now
issue ref: https://github.com/prometheus-community/postgres_exporter/issues/850