### PR TITLE
Bugfix: Make statsreset nullable

### DIFF
--- a/collector/pg_stat_database.go
+++ b/collector/pg_stat_database.go
@@ -348,8 +348,7 @@ func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance
 		var statsResetMetric float64
 		if !statsReset.Valid {
 			level.Debug(c.log).Log("msg", "Skipping collecting metric because it has no stats_reset")
-			statsResetMetric = 0.0
-		} else {
+		if statsReset.Valid {
 			statsResetMetric = float64(statsReset.Time.Unix())
 		}
 

--- a/collector/pg_stat_database.go
+++ b/collector/pg_stat_database.go
@@ -345,10 +345,12 @@ func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance
 			continue
 		}
 
-		statsResetMetric := 0.0
+		var statsResetMetric float64
 		if !statsReset.Valid {
 			level.Debug(c.log).Log("msg", "Skipping collecting metric because it has no stats_reset")
-			statsResetMetric = float64(statsReset.Time.Unix()),
+			statsResetMetric = 0.0
+		} else {
+			statsResetMetric = float64(statsReset.Time.Unix())
 		}
 
 		labels := []string{datid.String, datname.String}

--- a/collector/pg_stat_database.go
+++ b/collector/pg_stat_database.go
@@ -344,9 +344,11 @@ func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance
 			level.Debug(c.log).Log("msg", "Skipping collecting metric because it has no blk_write_time")
 			continue
 		}
+
+		statsResetMetric := 0.0
 		if !statsReset.Valid {
 			level.Debug(c.log).Log("msg", "Skipping collecting metric because it has no stats_reset")
-			continue
+			statsResetMetric = float64(statsReset.Time.Unix()),
 		}
 
 		labels := []string{datid.String, datname.String}
@@ -466,7 +468,7 @@ func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance
 		ch <- prometheus.MustNewConstMetric(
 			statDatabaseStatsReset,
 			prometheus.CounterValue,
-			float64(statsReset.Time.Unix()),
+			statsResetMetric,
 			labels...,
 		)
 	}

--- a/collector/pg_stat_database.go
+++ b/collector/pg_stat_database.go
@@ -347,7 +347,8 @@ func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance
 
 		statsResetMetric := 0.0
 		if !statsReset.Valid {
-			level.Debug(c.log).Log("msg", "Skipping collecting metric because it has no stats_reset")
+			level.Debug(c.log).Log("msg", "No metric for stats_reset, will collect 0 instead")
+		}
 		if statsReset.Valid {
 			statsResetMetric = float64(statsReset.Time.Unix())
 		}

--- a/collector/pg_stat_database.go
+++ b/collector/pg_stat_database.go
@@ -345,7 +345,7 @@ func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance
 			continue
 		}
 
-		var statsResetMetric float64
+		statsResetMetric := 0.0
 		if !statsReset.Valid {
 			level.Debug(c.log).Log("msg", "Skipping collecting metric because it has no stats_reset")
 		if statsReset.Valid {

--- a/collector/pg_stat_database_test.go
+++ b/collector/pg_stat_database_test.go
@@ -406,3 +406,101 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}
 }
+
+func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening a stub db connection: %s", err)
+	}
+	defer db.Close()
+
+	inst := &instance{db: db}
+
+	columns := []string{
+		"datid",
+		"datname",
+		"numbackends",
+		"xact_commit",
+		"xact_rollback",
+		"blks_read",
+		"blks_hit",
+		"tup_returned",
+		"tup_fetched",
+		"tup_inserted",
+		"tup_updated",
+		"tup_deleted",
+		"conflicts",
+		"temp_files",
+		"temp_bytes",
+		"deadlocks",
+		"blk_read_time",
+		"blk_write_time",
+		"stats_reset",
+	}
+
+	rows := sqlmock.NewRows(columns).
+		AddRow(
+			"pid",
+			"postgres",
+			354,
+			4945,
+			289097744,
+			1242257,
+			int64(3275602074),
+			89320867,
+			450139,
+			2034563757,
+			0,
+			int64(2725688749),
+			23,
+			52,
+			74,
+			925,
+			16,
+			823,
+			nil)
+
+	mock.ExpectQuery(sanitizeQuery(statDatabaseQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		c := PGStatDatabaseCollector{
+			log: log.With(log.NewNopLogger(), "collector", "pg_stat_database"),
+		}
+
+		if err := c.Update(context.Background(), inst, ch); err != nil {
+			t.Errorf("Error calling PGStatDatabaseCollector.Update: %s", err)
+		}
+	}()
+
+	expected := []MetricResult{
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_GAUGE, value: 354},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 4945},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 289097744},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 1242257},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 3275602074},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 89320867},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 450139},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 2034563757},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 2725688749},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 23},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 52},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 74},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 925},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 16},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 823},
+		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0},
+	}
+
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			m := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, m)
+		}
+	})
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}


### PR DESCRIPTION
Null is a legit value for statsReset and we should treat it as such. That being said, not clear what the value should be if the timestamp is null