### PR TITLE
Delay database connection until scrape

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -166,6 +166,14 @@ func (p PostgresCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect implements the prometheus.Collector interface.
 func (p PostgresCollector) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.TODO()
+
+	// Set up the database connection for the collector.
+	err := p.instance.setup()
+	if err != nil {
+		level.Error(p.logger).Log("msg", "Error opening connection to database", "err", err)
+		return
+	}
+
 	wg := sync.WaitGroup{}
 	wg.Add(len(p.Collectors))
 	for name, c := range p.Collectors {

--- a/collector/probe.go
+++ b/collector/probe.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/postgres_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -74,6 +75,13 @@ func (pc *ProbeCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (pc *ProbeCollector) Collect(ch chan<- prometheus.Metric) {
+	// Set up the database connection for the collector.
+	err := pc.instance.setup()
+	if err != nil {
+		level.Error(pc.logger).Log("msg", "Error opening connection to database", "err", err)
+		return
+	}
+
 	wg := sync.WaitGroup{}
 	wg.Add(len(pc.collectors))
 	for name, c := range pc.collectors {


### PR DESCRIPTION
This no longer returns an error when creating a collector.instance when the database cannot be reached for the version query. This will resolve the entire postgresCollector not being registered for metrics collection when a database is not available. If the version query fails, the scrape will fail.
    
Resolves #880