### PR TITLE
fix pg_replication_lag_seconds

### DIFF
--- a/collector/pg_replication.go
+++ b/collector/pg_replication.go
@@ -55,6 +55,7 @@ var (
 	pgReplicationQuery = `SELECT
 	CASE
 		WHEN NOT pg_is_in_recovery() THEN 0
+                WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN 0
 		ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
 	END AS lag,
 	CASE


### PR DESCRIPTION
Since postgres_exporter is being tested for versions above 10, I suggest replacing 
```
                WHEN NOT pg_is_in_recovery() THEN 0
		ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
```
to
```
		WHEN NOT pg_is_in_recovery() THEN 0
                WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN 0
		ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
```

Changed the way `pg_last_xact_replay_timestamp` works after 9.3

https://github.com/prometheus-community/postgres_exporter/issues/385