### PR TITLE
WAL functions cannot be executed in standby servers

### DIFF
--- a/cmd/postgres_exporter/queries.go
+++ b/cmd/postgres_exporter/queries.go
@@ -82,6 +82,7 @@ var queryOverrides = map[string][]OverrideQuery{
 			`
 			SELECT slot_name, database, active, pg_xlog_location_diff(pg_current_xlog_location(), restart_lsn)
 			FROM pg_replication_slots
+			WHERE pg_is_in_recovery() = False
 			`,
 		},
 		{
@@ -89,6 +90,7 @@ var queryOverrides = map[string][]OverrideQuery{
 			`
 			SELECT slot_name, database, active, pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)
 			FROM pg_replication_slots
+			WHERE pg_is_in_recovery() = False
 			`,
 		},
 	},


### PR DESCRIPTION
WAL functions cannot be executed in standby servers

```
ERROR:  recovery is in progress
HINT:  WAL control functions cannot be executed during recovery.
```

In PostgreSQL 16 replication slots persist in the standby servers. 
This is also the case when using extensions like pg_failover_slots that transfer the slot information to the standby.

This condition will make those queries to return values only in the primary node avoiding the errors.