### PR TITLE
Fix cross-compilation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ auth_modules:
 To build the Docker image:
 
     make promu
-    promu crossbuild -p linux/amd64 -p linux/armv7 -p linux/amd64 -p linux/ppc64le
+    promu crossbuild -p linux/amd64 -p linux/armv7 -p linux/arm64 -p linux/ppc64le
     make docker
 
 This will build the docker image as `prometheuscommunity/postgres_exporter:${branch}`.


### PR DESCRIPTION
The cross-compilation command currently lists amd64 twice. This fixes it by changing the second to arm64.