### PR TITLE
stat_user_tables: Add total size metric

### DIFF
--- a/collector/pg_stat_user_tables_test.go
+++ b/collector/pg_stat_user_tables_test.go
@@ -71,7 +71,8 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 		"vacuum_count",
 		"autovacuum_count",
 		"analyze_count",
-		"autoanalyze_count"}
+		"autoanalyze_count",
+		"total_size"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("postgres",
 			"public",
@@ -94,7 +95,8 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 			11,
 			12,
 			13,
-			14)
+			14,
+			15)
 	mock.ExpectQuery(sanitizeQuery(statUserTablesQuery)).WillReturnRows(rows)
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -170,9 +172,11 @@ func TestPGStatUserTablesCollectorNullValues(t *testing.T) {
 		"vacuum_count",
 		"autovacuum_count",
 		"analyze_count",
-		"autoanalyze_count"}
+		"autoanalyze_count",
+		"total_size"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("postgres",
+			nil,
 			nil,
 			nil,
 			nil,


### PR DESCRIPTION
This adds a new `pg_stat_user_tables_total_size` metric to the stat_user_tables collector. It uses the [`pg_total_relation_size()`](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE) function. (I had been using this via a modification to the query YAML file previously)

Note that #847 does something similar, but as a separate collector. This query is only scoped to user tables, not all relations.