### PR TITLE
Adds 1kB and 2kB units

### DIFF
--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -129,7 +129,7 @@ func (s *pgSetting) normaliseUnit() (val float64, unit string, err error) {
 		return
 	case "ms", "s", "min", "h", "d":
 		unit = "seconds"
-	case "B", "kB", "MB", "GB", "TB", "4kB", "8kB", "16kB", "32kB", "64kB", "16MB", "32MB", "64MB":
+	case "B", "kB", "MB", "GB", "TB", "1kB", "2kB", "4kB", "8kB", "16kB", "32kB", "64kB", "16MB", "32MB", "64MB":
 		unit = "bytes"
 	default:
 		err = fmt.Errorf("Unknown unit for runtime variable: %q", s.unit)
@@ -158,6 +158,10 @@ func (s *pgSetting) normaliseUnit() (val float64, unit string, err error) {
 		val *= math.Pow(2, 30)
 	case "TB":
 		val *= math.Pow(2, 40)
+	case "1kB":
+		val *= math.Pow(2, 10)
+	case "2kB":
+		val *= math.Pow(2, 11)
 	case "4kB":
 		val *= math.Pow(2, 12)
 	case "8kB":


### PR DESCRIPTION
These units can show up if you compile postgres  with a wal-blocksize of 1 or 2.
```
./configure --with-blocksize=8 --with-segsize=1 --with-wal-blocksize=2
```

Here's an admittedly cruddy Dockerfile to reproduce:
```
from debian:stable

RUN useradd -ms /bin/bash postgres
WORKDIR /home/postgres

RUN echo "deb http://deb.debian.org/debian/ bookworm main contrib non-free" > /etc/apt/sources.list
RUN apt-get update && apt-get upgrade
RUN apt-get install -y curl gcc libreadline8 libreadline-dev openssl zlib1g zlib1g-dev make
RUN curl https://ftp.postgresql.org/pub/source/v15.3/postgresql-15.3.tar.gz > postgresql-15.3.tar.gz
RUN tar xf postgresql-15.3.tar.gz

WORKDIR /home/postgres/postgresql-15.3
RUN ./configure --with-blocksize=8 --with-segsize=1 --with-wal-blocksize=1
RUN make
RUN make install
RUN /sbin/ldconfig /usr/local/pgsql/lib

USER postgres
ENV LD_LIBRARY_PATH=/usr/local/pgsql/lib
ENV PATH=/usr/local/pgsql/bin:$PATH
RUN initdb -D ~/data

WORKDIR /home/postgres
COPY run.sh run.sh
COPY data/pg_hba.conf data/pg_hba.conf
COPY postgresql.conf /home/postgres/data/postgresql.conf

CMD postgres -D ~/data
```