### PR TITLE
Add error log when probe collector creation fails

### DIFF
--- a/cmd/postgres_exporter/probe.go
+++ b/cmd/postgres_exporter/probe.go
@@ -85,6 +85,7 @@ func handleProbe(logger log.Logger, excludeDatabases []string) http.HandlerFunc 
 		// Run the probe
 		pc, err := collector.NewProbeCollector(tl, excludeDatabases, registry, dsn)
 		if err != nil {
+			level.Error(logger).Log("msg", "Error creating probe collector", "err", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
This would help debug a scenario like #917 