### PR TITLE
docs(mixin): go get -> go install

### DIFF
--- a/postgres_mixin/README.md
+++ b/postgres_mixin/README.md
@@ -11,8 +11,8 @@ for Grafana.
 To use them, you need to have `mixtool` and `jsonnetfmt` installed. If you
 have a working Go development environment, it's easiest to run the following:
 ```bash
-$ go get github.com/monitoring-mixins/mixtool/cmd/mixtool
-$ go get github.com/google/go-jsonnet/cmd/jsonnetfmt
+$ go install github.com/monitoring-mixins/mixtool/cmd/mixtool
+$ go install github.com/google/go-jsonnet/cmd/jsonnetfmt
 ```
 
 You can then build the Prometheus rules files `alerts.yaml` and


### PR DESCRIPTION
> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
>
> In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod. Specifically, go get will always act as if the -d flag were enabled.

More information: https://go.dev/doc/go-get-install-deprecation