### PR TITLE
Fixed postgresql>=10 secondary server lag always 0, SuperQ proposed a…

### DIFF
--- a/collector/pg_replication_test.go
+++ b/collector/pg_replication_test.go
@@ -34,7 +34,8 @@ func TestPgReplicationCollector(t *testing.T) {
 	columns := []string{"lag", "is_replica"}
 	rows := sqlmock.NewRows(columns).
 		AddRow(1000, 1)
-	mock.ExpectQuery(sanitizeQuery(pgReplicationQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(pgReplicationQueryBeforeVersion10)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(pgReplicationQueryAfterVersion10)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {


### PR DESCRIPTION
Fixed postgresql>=10 secondary server lag always 0, SuperQ proposed a more clean code solution :), pg_replication_test modified to test pgReplicationQueryBeforeVersion10 and pgReplicationQueryAfterVersion10