### PR TITLE
Fixed postgresql>=10 secondary server lag always 0, SuperQ proposed a…

### DIFF
--- a/collector/pg_replication.go
+++ b/collector/pg_replication.go
@@ -15,7 +15,7 @@ package collector
 
 import (
 	"context"
-
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -52,23 +52,35 @@ var (
 		[]string{}, nil,
 	)
 
-	pgReplicationQuery = `SELECT
+	pgReplicationQueryBeforeVersion10 = `SELECT
 	CASE
 		WHEN NOT pg_is_in_recovery() THEN 0
-                WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN 0
+        WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN 0
 		ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
 	END AS lag,
 	CASE
 		WHEN pg_is_in_recovery() THEN 1
 		ELSE 0
 	END as is_replica`
+
+	pgReplicationQueryAfterVersion10 = `SELECT
+    CASE
+        WHEN NOT pg_is_in_recovery() THEN 0
+        ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
+    END AS lag,
+    CASE
+        WHEN pg_is_in_recovery() THEN 1
+        ELSE 0
+    END as is_replica`
 )
 
 func (c *PGReplicationCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
-	row := db.QueryRowContext(ctx,
-		pgReplicationQuery,
-	)
+	query := pgReplicationQueryBeforeVersion10
+	if instance.version.GE(semver.MustParse("10.0.0")) {
+		query = pgReplicationQueryAfterVersion10
+	}
+	row := db.QueryRowContext(ctx, query)
 
 	var lag float64
 	var isReplica int64

--- a/collector/pg_replication_test.go
+++ b/collector/pg_replication_test.go
@@ -34,7 +34,11 @@ func TestPgReplicationCollector(t *testing.T) {
 	columns := []string{"lag", "is_replica"}
 	rows := sqlmock.NewRows(columns).
 		AddRow(1000, 1)
-	mock.ExpectQuery(sanitizeQuery(pgReplicationQuery)).WillReturnRows(rows)
+	if instance.version.GE(semver.MustParse("10.0.0")) {
+		mock.ExpectQuery(sanitizeQuery(pgReplicationQueryAfterVersion10)).WillReturnRows(rows)
+	} else {
+		mock.ExpectQuery(sanitizeQuery(pgReplicationQueryBeforeVersion10)).WillReturnRows(rows)
+	}
 
 	ch := make(chan prometheus.Metric)
 	go func() {


### PR DESCRIPTION
Fixed postgresql>=10 secondary server lag always 0, SuperQ proposed a more clean code solution :), pg_replication_test modified to test pgReplicationQueryBeforeVersion10 and pgReplicationQueryAfterVersion10