### PR TITLE
Fixed postgresql>=10 secondary server lag always 0, SuperQ proposed a…

### DIFF
--- a/collector/pg_replication.go
+++ b/collector/pg_replication.go
@@ -15,7 +15,7 @@ package collector
 
 import (
 	"context"
-
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -52,23 +52,36 @@ var (
 		[]string{}, nil,
 	)
 
-	pgReplicationQuery = `SELECT
+	pgReplicationQueryBeforeVersion10 = `SELECT
 	CASE
 		WHEN NOT pg_is_in_recovery() THEN 0
-                WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN 0
+        WHEN pg_last_wal_receive_lsn () = pg_last_wal_replay_lsn () THEN 0
 		ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
 	END AS lag,
 	CASE
 		WHEN pg_is_in_recovery() THEN 1
 		ELSE 0
 	END as is_replica`
+
+	pgReplicationQueryAfterVersion10 = `SELECT
+    CASE
+        WHEN NOT pg_is_in_recovery() THEN 0
+        ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
+    END AS lag,
+    CASE
+        WHEN pg_is_in_recovery() THEN 1
+        ELSE 0
+    END as is_replica`
 )
 
 func (c *PGReplicationCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
-	row := db.QueryRowContext(ctx,
-		pgReplicationQuery,
-	)
+	query := pgReplicationQueryBeforeVersion10
+	if instance.version.GE(semver.MustParse("10.0.0")) {
+		query = pgReplicationQueryAfterVersion10
+	}
+
+	row := db.QueryRowContext(ctx, query)
 
 	var lag float64
 	var isReplica int64


### PR DESCRIPTION
Fixed postgresql>=10 secondary server lag always 0, SuperQ proposed a more clean code solution :), pg_replication_test modified to test pgReplicationQueryBeforeVersion10 or pgReplicationQueryAfterVersion10 depending of the postgresql version