### PR TITLE
fix: longRunningTransactionsAgeInSeconds

### DIFF
--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -52,7 +52,7 @@ var (
 	longRunningTransactionsQuery = `
 	SELECT
 		COUNT(*) as transactions,
-   		MAX(EXTRACT(EPOCH FROM clock_timestamp())) AS oldest_timestamp_seconds
+		MIN(EXTRACT(EPOCH FROM xact_start)) AS oldest_timestamp_seconds
     FROM pg_catalog.pg_stat_activity
     WHERE state is distinct from 'idle' AND query not like 'autovacuum:%'
 	`


### PR DESCRIPTION
- clock_timestamp will just return the current timestamp
- what we actually want to know is the lowest timestamp of the xact_start column

Please also see:
https://github.com/prometheus-community/postgres_exporter/pull/836#discussion_r1295748514
and the original can be found here:
https://gitlab.com/gitlab-cookbooks/gitlab-exporters/-/blob/master/templates/postgres_exporter/queries.yaml.erb#L954

(the originally proposed version `MAX(EXTRACT(EPOCH FROM (clock_timestamp() - xact_start))) AS age_in_seconds` is also correct, but return the seconds, not the timestamp.

Using the current version the graphs look like this (flat line as this will always match the current time):
![Screenshot 2023-11-30 at 15 51 56](https://github.com/prometheus-community/postgres_exporter/assets/533172/6c9aa540-eb18-4178-a7b2-e62b6d2ab9a0)
