### PR TITLE
Add connection limits metrics for pg_roles and pg_database

### DIFF
--- a/collector/pg_database.go
+++ b/collector/pg_database.go
@@ -63,7 +63,7 @@ var (
 		[]string{"datname"}, nil,
 	)
 
-	pgDatabaseQuery     = "SELECT pg_database.datname,pg_database.datconnlimit FROM pg_database;"
+	pgDatabaseQuery     = "SELECT pg_database.datname, pg_database.datconnlimit FROM pg_database;"
 	pgDatabaseSizeQuery = "SELECT pg_database_size($1)"
 )
 

--- a/collector/pg_database_test.go
+++ b/collector/pg_database_test.go
@@ -31,8 +31,8 @@ func TestPGDatabaseCollector(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	mock.ExpectQuery(sanitizeQuery(pgDatabaseQuery)).WillReturnRows(sqlmock.NewRows([]string{"datname"}).
-		AddRow("postgres"))
+	mock.ExpectQuery(sanitizeQuery(pgDatabaseQuery)).WillReturnRows(sqlmock.NewRows([]string{"datname", "datconnlimit"}).
+		AddRow("postgres", 15))
 
 	mock.ExpectQuery(sanitizeQuery(pgDatabaseSizeQuery)).WithArgs("postgres").WillReturnRows(sqlmock.NewRows([]string{"pg_database_size"}).
 		AddRow(1024))
@@ -47,6 +47,7 @@ func TestPGDatabaseCollector(t *testing.T) {
 	}()
 
 	expected := []MetricResult{
+		{labels: labelMap{"datname": "postgres"}, value: 15, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"datname": "postgres"}, value: 1024, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
@@ -71,8 +72,8 @@ func TestPGDatabaseCollectorNullMetric(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	mock.ExpectQuery(sanitizeQuery(pgDatabaseQuery)).WillReturnRows(sqlmock.NewRows([]string{"datname"}).
-		AddRow("postgres"))
+	mock.ExpectQuery(sanitizeQuery(pgDatabaseQuery)).WillReturnRows(sqlmock.NewRows([]string{"datname", "datconnlimit"}).
+		AddRow("postgres", nil))
 
 	mock.ExpectQuery(sanitizeQuery(pgDatabaseSizeQuery)).WithArgs("postgres").WillReturnRows(sqlmock.NewRows([]string{"pg_database_size"}).
 		AddRow(nil))
@@ -87,6 +88,7 @@ func TestPGDatabaseCollectorNullMetric(t *testing.T) {
 	}()
 
 	expected := []MetricResult{
+		{labels: labelMap{"datname": "postgres"}, value: 0, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"datname": "postgres"}, value: 0, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {

--- a/collector/pg_roles.go
+++ b/collector/pg_roles.go
@@ -48,7 +48,7 @@ var (
 		[]string{"rolname"}, nil,
 	)
 
-	pgRolesConnectionLimitsQuery = "select pg_roles.rolname,pg_roles.rolconnlimit FROM pg_roles"
+	pgRolesConnectionLimitsQuery = "SELECT pg_roles.rolname, pg_roles.rolconnlimit FROM pg_roles"
 )
 
 // Update implements Collector and exposes roles connection limits.

--- a/collector/pg_roles.go
+++ b/collector/pg_roles.go
@@ -71,15 +71,15 @@ func (c PGRolesCollector) Update(ctx context.Context, instance *instance, ch cha
 			return err
 		}
 
-		rolnameLabel := "unknown"
-		if rolname.Valid {
-			rolnameLabel = rolname.String
+		if !rolname.Valid {
+			continue
 		}
+		rolnameLabel := rolname.String
 
-		connLimitMetric := 0.0
-		if connLimit.Valid {
-			connLimitMetric = float64(connLimit.Int64)
+		if !connLimit.Valid {
+			continue
 		}
+		connLimitMetric := float64(connLimit.Int64)
 
 		ch <- prometheus.MustNewConstMetric(
 			pgRolesConnectionLimitsDesc,

--- a/collector/pg_roles.go
+++ b/collector/pg_roles.go
@@ -1,0 +1,91 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const rolesSubsystem = "roles"
+
+func init() {
+	registerCollector(rolesSubsystem, defaultEnabled, NewPGRolesCollector)
+}
+
+type PGRolesCollector struct {
+	log log.Logger
+}
+
+func NewPGRolesCollector(config collectorConfig) (Collector, error) {
+	return &PGRolesCollector{
+		log: config.logger,
+	}, nil
+}
+
+var (
+	pgRolesConnectionLimitsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(
+			namespace,
+			rolesSubsystem,
+			"connection_limit",
+		),
+		"Connection limit set for the role",
+		[]string{"rolname"}, nil,
+	)
+
+	pgRolesConnectionLimitsQuery = "select pg_roles.rolname,pg_roles.rolconnlimit FROM pg_roles"
+)
+
+// Update implements Collector and exposes roles connection limits.
+// It is called by the Prometheus registry when collecting metrics.
+func (c PGRolesCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+	db := instance.getDB()
+	// Query the list of databases
+	rows, err := db.QueryContext(ctx,
+		pgRolesConnectionLimitsQuery,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rolname sql.NullString
+		var connLimit sql.NullInt64
+		if err := rows.Scan(&rolname, &connLimit); err != nil {
+			return err
+		}
+
+		rolnameLabel := "unknown"
+		if rolname.Valid {
+			rolnameLabel = rolname.String
+		}
+
+		connLimitMetric := 0.0
+		if connLimit.Valid {
+			connLimitMetric = float64(connLimit.Int64)
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			pgRolesConnectionLimitsDesc,
+			prometheus.GaugeValue, connLimitMetric, rolnameLabel,
+		)
+	}
+
+	return rows.Err()
+}

--- a/collector/pg_roles.go
+++ b/collector/pg_roles.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Prometheus Authors
+// Copyright 2024 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/collector/pg_roles_test.go
+++ b/collector/pg_roles_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestPGRolesCollector(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening a stub db connection: %s", err)
+	}
+	defer db.Close()
+
+	inst := &instance{db: db}
+
+	mock.ExpectQuery(sanitizeQuery(pgRolesConnectionLimitsQuery)).WillReturnRows(sqlmock.NewRows([]string{"rolname", "rolconnlimit"}).
+		AddRow("postgres", 15))
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		c := PGRolesCollector{}
+		if err := c.Update(context.Background(), inst, ch); err != nil {
+			t.Errorf("Error calling PGRolesCollector.Update: %s", err)
+		}
+	}()
+
+	expected := []MetricResult{
+		{labels: labelMap{"rolname": "postgres"}, value: 15, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			m := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, m)
+		}
+	})
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}
+
+func TestPGRolesCollectorNullMetric(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening a stub db connection: %s", err)
+	}
+	defer db.Close()
+
+	inst := &instance{db: db}
+
+	mock.ExpectQuery(sanitizeQuery(pgRolesConnectionLimitsQuery)).WillReturnRows(sqlmock.NewRows([]string{"rolname", "rolconnlimit"}).
+		AddRow(nil, nil))
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		c := PGRolesCollector{}
+
+		if err := c.Update(context.Background(), inst, ch); err != nil {
+			t.Errorf("Error calling PGRolesCollector.Update: %s", err)
+		}
+	}()
+
+	expected := []MetricResult{
+		{labels: labelMap{"rolname": "unknown"}, value: 0, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			m := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, m)
+		}
+	})
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/prometheus-community/postgres_exporter/issues/996

This PR adds the possibility to gather metrics for Database and roles connection limits.
