### PR TITLE
use Info level for excluded databases log message

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -93,7 +93,7 @@ func main() {
 	}
 
 	excludedDatabases := strings.Split(*excludeDatabases, ",")
-	logger.Log("msg", "Excluded databases", "databases", fmt.Sprintf("%v", excludedDatabases))
+	level.Info(logger).Log("msg", "Excluded databases", "databases", fmt.Sprintf("%v", excludedDatabases))
 
 	if *queriesPath != "" {
 		level.Warn(logger).Log("msg", "The extended queries.yaml config is DEPRECATED", "file", *queriesPath)


### PR DESCRIPTION
This is the only log message which didn't specify a level in the postgres_exporter. I am unsure if this log message should be info or debug, but leaning towards the more important since previously it would just always log.

The way I validated this was the only non-leveled logger was via grep. Both of these only returned this callsite previously:

``` shell
git grep 'logger\.Log'
git grep '\.Log(' | grep -v level
```
