### PR TITLE
Add usename and application_name to pg_locks_count

### DIFF
--- a/collector/pg_locks_test.go
+++ b/collector/pg_locks_test.go
@@ -31,8 +31,9 @@ func TestPGLocksCollector(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	rows := sqlmock.NewRows([]string{"datname", "mode", "count"}).
-		AddRow("test", "exclusivelock", 42)
+	rows := sqlmock.NewRows([]string{"datname", "mode", "usename", "application_name", "count"}).
+		AddRow("test", "exclusivelock", "", "", 42).
+		AddRow("test2", "exclusivelock", "myaccount", "myapp", 21)
 
 	mock.ExpectQuery(sanitizeQuery(pgLocksQuery)).WillReturnRows(rows)
 
@@ -46,7 +47,8 @@ func TestPGLocksCollector(t *testing.T) {
 	}()
 
 	expected := []MetricResult{
-		{labels: labelMap{"datname": "test", "mode": "exclusivelock"}, value: 42, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"datname": "test", "mode": "exclusivelock", "usename": "", "application_name": ""}, value: 42, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"datname": "test2", "mode": "exclusivelock", "usename": "myaccount", "application_name": "myapp"}, value: 21, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range expected {


### PR DESCRIPTION
Hi,

We have a use case where several application are using the same database for update, and currently there is no easy way to determine which process is causing most of the locks.

This PR adds `usename` and `application_name` to `pg_locks_count`, in the same spirit as https://github.com/prometheus-community/postgres_exporter/pull/673