### PR TITLE
Export last replay age in replication collector

### DIFF
--- a/collector/pg_replication_test.go
+++ b/collector/pg_replication_test.go
@@ -31,9 +31,9 @@ func TestPgReplicationCollector(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	columns := []string{"lag", "is_replica"}
+	columns := []string{"lag", "is_replica", "last_replay"}
 	rows := sqlmock.NewRows(columns).
-		AddRow(1000, 1)
+		AddRow(1000, 1, 3)
 	mock.ExpectQuery(sanitizeQuery(pgReplicationQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -49,6 +49,7 @@ func TestPgReplicationCollector(t *testing.T) {
 	expected := []MetricResult{
 		{labels: labelMap{}, value: 1000, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 3, metricType: dto.MetricType_GAUGE},
 	}
 
 	convey.Convey("Metrics comparison", t, func() {


### PR DESCRIPTION
The exported replication lag does not handle all failure modes, and can report 0 for replicas that are out of sync and incapable of recovery.

A proper replacement for that metric would require a different approach (see e.g. #1007), but for a lot of folks, simply exporting the age of the last replay can provide a pretty strong signal for something being amiss.

I think this solution might be preferable to #977, though the lag metric needs to be fixed or abandoned eventually.