### PR TITLE
Make walreceiver collector useful w/o repmgr

### DIFF
--- a/collector/pg_stat_walreceiver.go
+++ b/collector/pg_stat_walreceiver.go
@@ -203,10 +203,6 @@ func (c *PGStatWalReceiverCollector) Update(ctx context.Context, instance *insta
 			c.log.Debug("Skipping wal receiver stats because latest_end_time is null")
 			continue
 		}
-		if !upstreamNode.Valid {
-			c.log.Debug("Skipping wal receiver stats because upstream_node is null")
-			continue
-		}
 		ch <- prometheus.MustNewConstMetric(
 			statWalReceiverReceiveStartLsn,
 			prometheus.CounterValue,
@@ -257,11 +253,15 @@ func (c *PGStatWalReceiverCollector) Update(ctx context.Context, instance *insta
 			latestEndTime.Float64,
 			labels...)
 
-		ch <- prometheus.MustNewConstMetric(
-			statWalReceiverUpstreamNode,
-			prometheus.GaugeValue,
-			float64(upstreamNode.Int64),
-			labels...)
+		if !upstreamNode.Valid {
+			c.log.Debug("Skipping wal receiver stats upstream_node because it is null")
+		} else {
+			ch <- prometheus.MustNewConstMetric(
+				statWalReceiverUpstreamNode,
+				prometheus.GaugeValue,
+				float64(upstreamNode.Int64),
+				labels...)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return err


### PR DESCRIPTION
In a streaming replication setup that was created without replication manager (`repmgr`), the `stat_wal_receiver` collector does not return any metrics, because one value it wants to export is not present.

This is rather overly opinionated. The missing metric is comparatively uninteresting and does not justify discarding all the others. And replication setups created without `repmgr` are not exactly rare.

This commit makes the one relevant metric optional and simply skips it if the respective value cannot be determined.