### PR TITLE
Update pg_long_running_transactions.go

### DIFF
--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -50,11 +50,13 @@ var (
 	)
 
 	longRunningTransactionsQuery = `
-	SELECT
-		COUNT(*) as transactions,
-   		MAX(EXTRACT(EPOCH FROM clock_timestamp())) AS oldest_timestamp_seconds
-    FROM pg_catalog.pg_stat_activity
-    WHERE state is distinct from 'idle' AND query not like 'autovacuum:%'
+	SELECT                                                              
+    COUNT(*) as transactions,
+    MAX(EXTRACT(EPOCH FROM clock_timestamp() - pg_stat_activity.xact_start)) AS oldest_timestamp_seconds
+FROM pg_catalog.pg_stat_activity
+WHERE state IS DISTINCT FROM 'idle'
+AND query NOT LIKE 'autovacuum:%'
+AND pg_stat_activity.xact_start IS NOT NULL;
 	`
 )
 


### PR DESCRIPTION
To extract time in seconds for pg_long_running_transactions_oldest_timestamp_seconds query which currently returns epoch time.