### PR TITLE
fix: handle pg_replication_slots on pg<13

### DIFF
--- a/collector/pg_replication_slot_test.go
+++ b/collector/pg_replication_slot_test.go
@@ -34,7 +34,7 @@ func TestPgReplicationSlotCollectorActive(t *testing.T) {
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("test_slot", "physical", 5, 3, true, 323906992, "reserved")
-	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -77,7 +77,7 @@ func TestPgReplicationSlotCollectorInActive(t *testing.T) {
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("test_slot", "physical", 6, 12, false, -4000, "extended")
-	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -120,7 +120,7 @@ func TestPgReplicationSlotCollectorActiveNil(t *testing.T) {
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("test_slot", "physical", 6, 12, nil, nil, "lost")
-	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -161,7 +161,7 @@ func TestPgReplicationSlotCollectorTestNilValues(t *testing.T) {
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow(nil, nil, nil, nil, true, nil, nil)
-	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {

--- a/collector/pg_replication_slot_test.go
+++ b/collector/pg_replication_slot_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/smartystreets/goconvey/convey"
@@ -29,12 +30,12 @@ func TestPgReplicationSlotCollectorActive(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("test_slot", "physical", 5, 3, true, 323906992, "reserved")
-	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotNewQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -72,12 +73,12 @@ func TestPgReplicationSlotCollectorInActive(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("test_slot", "physical", 6, 12, false, -4000, "extended")
-	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotNewQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -115,12 +116,12 @@ func TestPgReplicationSlotCollectorActiveNil(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("test_slot", "physical", 6, 12, nil, nil, "lost")
-	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotNewQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -156,12 +157,12 @@ func TestPgReplicationSlotCollectorTestNilValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
 		AddRow(nil, nil, nil, nil, true, nil, nil)
-	mock.ExpectQuery(sanitizeQuery(replicationSlotQuery(columns))).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotNewQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {


### PR DESCRIPTION
This PR fixes #1097 to handle pg < 13 for `pg_replication_slots`.
The original feat was #1027 