### PR TITLE
Fix to replace dashes with underscore in the metric names

### DIFF
--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -67,7 +67,7 @@ type pgSetting struct {
 func (s *pgSetting) metric(labels prometheus.Labels) prometheus.Metric {
 	var (
 		err       error
-		name      = strings.Replace(strings.Replace(s.name, ".", "_", -1), "-", "_", -1) 
+		name      = strings.Replace(strings.Replace(s.name, ".", "_", -1), "-", "_", -1)
 		unit      = s.unit // nolint: ineffassign
 		shortDesc = fmt.Sprintf("Server Parameter: %s", s.name)
 		subsystem = "settings"

--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -67,7 +67,7 @@ type pgSetting struct {
 func (s *pgSetting) metric(labels prometheus.Labels) prometheus.Metric {
 	var (
 		err       error
-		name      = strings.Replace(s.name, ".", "_", -1)
+		name      = strings.Replace(strings.Replace(s.name, ".", "_", -1), "-", "_", -1) 
 		unit      = s.unit // nolint: ineffassign
 		shortDesc = fmt.Sprintf("Server Parameter: %s", s.name)
 		subsystem = "settings"


### PR DESCRIPTION
This fix is to cater to the Issue - https://github.com/prometheus-community/postgres_exporter/issues/1102, where the exporter is crashing with the following signature.
```
panic: "pg_settings_mem_guard_enable-auth-hook" is not a valid metric name

goroutine 52 [running]:
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.20.5/prometheus/value.go:129
main.(*pgSetting).metric(0xc00020c640, 0xc00020a2a0)
	/app/cmd/postgres_exporter/pg_setting.go:99 +0x2ff
main.querySettings(0xc00022e070, 0xc00025a000)
	/app/cmd/postgres_exporter/pg_setting.go:55 +0x1d8
main.(*Server).Scrape(0xc00025a000, 0xc00022e070, 0x0?)
	/app/cmd/postgres_exporter/server.go:120 +0xc8
main.(*Exporter).scrapeDSN(0xc000174000, 0xc00022e070, {0xc0000be140, 0x92})
	/app/cmd/postgres_exporter/datasource.go:114 +0x132
main.(*Exporter).scrape(0xc000174000, 0xc00022e070)
	/app/cmd/postgres_exporter/postgres_exporter.go:678 +0x16b
main.(*Exporter).Collect(0xc000174000, 0xc00022e070)
	/app/cmd/postgres_exporter/postgres_exporter.go:567 +0x25
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/go/pkg/mod/github.com/prometheus/client_golang@v1.20.5/prometheus/registry.go:458 +0xe5
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 39
	/go/pkg/mod/github.com/prometheus/client_golang@v1.20.5/prometheus/registry.go:548 +0xbab
```