### PR TITLE
Skip pg_stat_checkpointer collector if pg<17

### DIFF
--- a/collector/pg_stat_checkpointer.go
+++ b/collector/pg_stat_checkpointer.go
@@ -110,8 +110,8 @@ var (
 func (c PGStatCheckpointerCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 
-	before17 := instance.version.Compare(semver.MustParse("17.0.0"))
-	if before17 < 0 {
+	before17 := instance.version.LT(semver.MustParse("17.0.0"))
+	if before17 {
 		c.log.Warn("pg_stat_checkpointer collector is not available on PostgreSQL < 17.0.0, skipping")
 		return nil
 	}

--- a/collector/pg_stat_checkpointer.go
+++ b/collector/pg_stat_checkpointer.go
@@ -16,7 +16,9 @@ package collector
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -29,10 +31,11 @@ func init() {
 }
 
 type PGStatCheckpointerCollector struct {
+	log *slog.Logger
 }
 
-func NewPGStatCheckpointerCollector(collectorConfig) (Collector, error) {
-	return &PGStatCheckpointerCollector{}, nil
+func NewPGStatCheckpointerCollector(config collectorConfig) (Collector, error) {
+	return &PGStatCheckpointerCollector{log: config.logger}, nil
 }
 
 var (
@@ -104,8 +107,15 @@ var (
 	FROM pg_stat_checkpointer;`
 )
 
-func (PGStatCheckpointerCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGStatCheckpointerCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
+
+	before17 := instance.version.Compare(semver.MustParse("17.0.0"))
+	if before17 < 0 {
+		c.log.Warn("pg_stat_checkpointer collector is not available on PostgreSQL < 17.0.0, skipping")
+		return nil
+	}
+
 	row := db.QueryRowContext(ctx, statCheckpointerQuery)
 
 	// num_timed           = nt  = bigint

--- a/collector/pg_stat_checkpointer_test.go
+++ b/collector/pg_stat_checkpointer_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/smartystreets/goconvey/convey"
@@ -30,7 +31,7 @@ func TestPGStatCheckpointerCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &instance{db: db, version: semver.MustParse("17.0.0")}
 
 	columns := []string{
 		"num_timed",
@@ -92,7 +93,7 @@ func TestPGStatCheckpointerCollectorNullValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &instance{db: db, version: semver.MustParse("17.0.0")}
 
 	columns := []string{
 		"num_timed",


### PR DESCRIPTION
Hello,

Here a fix for https://github.com/prometheus-community/postgres_exporter/pull/1072#issuecomment-2503906073 where the collector fails on pg<17 when we use the exporter with the multi-target pattern

Thank you!