### PR TITLE
Prevent password from being printed to logs

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -678,7 +678,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		if err := e.scrapeDSN(ch, dsn); err != nil {
 			errorsCount++
 
-			logger.Error("error scraping dsn", "err", err, "dsn", dsn)
+			logger.Error("error scraping dsn", "err", err, "dsn", loggableDSN(dsn))
 
 			if _, ok := err.(*ErrorConnectToServer); ok {
 				connectionErrorsCount++


### PR DESCRIPTION
Remove Password from logs when printing dsn.