### PR TITLE
Fix: Handle incoming labels with invalid UTF-8

### DIFF
--- a/cmd/postgres_exporter/util.go
+++ b/cmd/postgres_exporter/util.go
@@ -159,7 +159,7 @@ func dbToString(t interface{}) (string, bool) {
 		// Try and convert to string
 		return string(v), true
 	case string:
-		return v, true
+		return strings.ToValidUTF8(v, "�"), true
 	case bool:
 		if v {
 			return "true", true


### PR DESCRIPTION
It's possible that incoming labels contain invalid UTF-8 characters. This results in a panic. This fix sanitizes the label's string to ensure only valid UTF-8 characters are included, by replacing invalid characters with � (REPLACEMENT CHARACTER)