### PR TITLE
Add datname label to pg_statio_user_indexes.

### DIFF
--- a/collector/pg_statio_user_indexes_test.go
+++ b/collector/pg_statio_user_indexes_test.go
@@ -30,6 +30,7 @@ func TestPgStatioUserIndexesCollector(t *testing.T) {
 	defer db.Close()
 	inst := &instance{db: db}
 	columns := []string{
+		"datname",
 		"schemaname",
 		"relname",
 		"indexrelname",
@@ -37,7 +38,7 @@ func TestPgStatioUserIndexesCollector(t *testing.T) {
 		"idx_blks_hit",
 	}
 	rows := sqlmock.NewRows(columns).
-		AddRow("public", "pgtest_accounts", "pgtest_accounts_pkey", 8, 9)
+		AddRow("postgres", "public", "pgtest_accounts", "pgtest_accounts_pkey", 8, 9)
 
 	mock.ExpectQuery(sanitizeQuery(statioUserIndexesQuery)).WillReturnRows(rows)
 
@@ -51,8 +52,8 @@ func TestPgStatioUserIndexesCollector(t *testing.T) {
 		}
 	}()
 	expected := []MetricResult{
-		{labels: labelMap{"schemaname": "public", "relname": "pgtest_accounts", "indexrelname": "pgtest_accounts_pkey"}, value: 8, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"schemaname": "public", "relname": "pgtest_accounts", "indexrelname": "pgtest_accounts_pkey"}, value: 9, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"datname": "postgres", "schemaname": "public", "relname": "pgtest_accounts", "indexrelname": "pgtest_accounts_pkey"}, value: 8, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"datname": "postgres", "schemaname": "public", "relname": "pgtest_accounts", "indexrelname": "pgtest_accounts_pkey"}, value: 9, metricType: dto.MetricType_COUNTER},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range expected {
@@ -73,6 +74,7 @@ func TestPgStatioUserIndexesCollectorNull(t *testing.T) {
 	defer db.Close()
 	inst := &instance{db: db}
 	columns := []string{
+		"datname",
 		"schemaname",
 		"relname",
 		"indexrelname",
@@ -80,7 +82,7 @@ func TestPgStatioUserIndexesCollectorNull(t *testing.T) {
 		"idx_blks_hit",
 	}
 	rows := sqlmock.NewRows(columns).
-		AddRow(nil, nil, nil, nil, nil)
+		AddRow(nil, nil, nil, nil, nil, nil)
 
 	mock.ExpectQuery(sanitizeQuery(statioUserIndexesQuery)).WillReturnRows(rows)
 
@@ -94,8 +96,8 @@ func TestPgStatioUserIndexesCollectorNull(t *testing.T) {
 		}
 	}()
 	expected := []MetricResult{
-		{labels: labelMap{"schemaname": "unknown", "relname": "unknown", "indexrelname": "unknown"}, value: 0, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"schemaname": "unknown", "relname": "unknown", "indexrelname": "unknown"}, value: 0, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"datname": "unknown", "schemaname": "unknown", "relname": "unknown", "indexrelname": "unknown"}, value: 0, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"datname": "unknown", "schemaname": "unknown", "relname": "unknown", "indexrelname": "unknown"}, value: 0, metricType: dto.MetricType_COUNTER},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range expected {


### PR DESCRIPTION
Add `datname` label to `pg_statio_user_indexes` metrics similar to `pg_statio_user_tables` where the `datname` label already exists.
This allows distinguishing indexes with the same fully qualified name (schema name and index name) within different databases running in a PostgreSQL instance.