### PR TITLE
Record table only size bytes as well in addition to the total size bytes

### DIFF
--- a/collector/pg_stat_user_tables.go
+++ b/collector/pg_stat_user_tables.go
@@ -157,7 +157,7 @@ var (
 		prometheus.Labels{},
 	)
 	statUserTablesOnlySize = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, userTableSubsystem, "only_size_bytes"),
+		prometheus.BuildFQName(namespace, userTableSubsystem, "table_size_bytes"),
 		"Total disk space used by only this table, in bytes",
 		[]string{"datname", "schemaname", "relname"},
 		prometheus.Labels{},

--- a/collector/pg_stat_user_tables.go
+++ b/collector/pg_stat_user_tables.go
@@ -186,8 +186,8 @@ var (
 		autovacuum_count,
 		analyze_count,
 		autoanalyze_count,
-		pg_total_relation_size(relid) as total_size,
-		pg_table_size(relid) as table_only_size
+		pg_indexes_size(relid) as indexes_size,
+		pg_table_size(relid) as table_size
 	FROM
 		pg_stat_user_tables`
 )

--- a/collector/pg_stat_user_tables_test.go
+++ b/collector/pg_stat_user_tables_test.go
@@ -72,8 +72,8 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 		"autovacuum_count",
 		"analyze_count",
 		"autoanalyze_count",
-		"total_size",
-		"table_only_size"}
+		"index_size",
+		"table_size"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("postgres",
 			"public",
@@ -177,8 +177,8 @@ func TestPGStatUserTablesCollectorNullValues(t *testing.T) {
 		"autovacuum_count",
 		"analyze_count",
 		"autoanalyze_count",
-		"total_size",
-		"table_only_size"}
+		"index_size",
+		"table_size"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("postgres",
 			nil,

--- a/collector/pg_stat_user_tables_test.go
+++ b/collector/pg_stat_user_tables_test.go
@@ -72,7 +72,8 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 		"autovacuum_count",
 		"analyze_count",
 		"autoanalyze_count",
-		"total_size"}
+		"total_size",
+		"table_only_size"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("postgres",
 			"public",
@@ -96,7 +97,8 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 			12,
 			13,
 			14,
-			15)
+			15,
+			16)
 	mock.ExpectQuery(sanitizeQuery(statUserTablesQuery)).WillReturnRows(rows)
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -128,6 +130,8 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 		{labels: labelMap{"datname": "postgres", "schemaname": "public", "relname": "a_table"}, metricType: dto.MetricType_COUNTER, value: 12},
 		{labels: labelMap{"datname": "postgres", "schemaname": "public", "relname": "a_table"}, metricType: dto.MetricType_COUNTER, value: 13},
 		{labels: labelMap{"datname": "postgres", "schemaname": "public", "relname": "a_table"}, metricType: dto.MetricType_COUNTER, value: 14},
+		{labels: labelMap{"datname": "postgres", "schemaname": "public", "relname": "a_table"}, metricType: dto.MetricType_GAUGE, value: 15},
+		{labels: labelMap{"datname": "postgres", "schemaname": "public", "relname": "a_table"}, metricType: dto.MetricType_GAUGE, value: 16},
 	}
 
 	convey.Convey("Metrics comparison", t, func() {
@@ -173,9 +177,11 @@ func TestPGStatUserTablesCollectorNullValues(t *testing.T) {
 		"autovacuum_count",
 		"analyze_count",
 		"autoanalyze_count",
-		"total_size"}
+		"total_size",
+		"table_only_size"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("postgres",
+			nil,
 			nil,
 			nil,
 			nil,
@@ -229,6 +235,8 @@ func TestPGStatUserTablesCollectorNullValues(t *testing.T) {
 		{labels: labelMap{"datname": "postgres", "schemaname": "unknown", "relname": "unknown"}, metricType: dto.MetricType_COUNTER, value: 0},
 		{labels: labelMap{"datname": "postgres", "schemaname": "unknown", "relname": "unknown"}, metricType: dto.MetricType_COUNTER, value: 0},
 		{labels: labelMap{"datname": "postgres", "schemaname": "unknown", "relname": "unknown"}, metricType: dto.MetricType_COUNTER, value: 0},
+		{labels: labelMap{"datname": "postgres", "schemaname": "unknown", "relname": "unknown"}, metricType: dto.MetricType_GAUGE, value: 0},
+		{labels: labelMap{"datname": "postgres", "schemaname": "unknown", "relname": "unknown"}, metricType: dto.MetricType_GAUGE, value: 0},
 	}
 
 	convey.Convey("Metrics comparison", t, func() {


### PR DESCRIPTION
pg_total_relation_size gets the size of the relation + indexes and toast, however we need to know just the size of the table itself. You can get this info from pg_table_size. Should be safe to add, this function was added back in 2010.