### PR TITLE
Feat: Improve Error Handling for Server.Scrape

### DIFF
--- a/cmd/postgres_exporter/server.go
+++ b/cmd/postgres_exporter/server.go
@@ -129,7 +129,7 @@ func (s *Server) Scrape(ch chan<- prometheus.Metric, disableSettingsMetrics bool
 	}
 	err = fmt.Errorf("queryNamespaceMappings errors encountered")
 	for namespace, errStr := range errMap {
-		err = fmt.Errorf("%s, %s namespace had the following error: %s", err, namespace, errStr)
+		err = fmt.Errorf("%s, namespace: %s error: %s", err, namespace, errStr)
 	}
 
 	return err

--- a/cmd/postgres_exporter/server.go
+++ b/cmd/postgres_exporter/server.go
@@ -119,6 +119,7 @@ func (s *Server) Scrape(ch chan<- prometheus.Metric, disableSettingsMetrics bool
 	if !disableSettingsMetrics && s.master {
 		if err = querySettings(ch, s); err != nil {
 			err = fmt.Errorf("error retrieving settings: %s", err)
+			return err
 		}
 	}
 

--- a/cmd/postgres_exporter/server.go
+++ b/cmd/postgres_exporter/server.go
@@ -124,8 +124,12 @@ func (s *Server) Scrape(ch chan<- prometheus.Metric, disableSettingsMetrics bool
 	}
 
 	errMap := queryNamespaceMappings(ch, s)
-	if len(errMap) > 0 {
-		err = fmt.Errorf("queryNamespaceMappings returned %d errors", len(errMap))
+	if len(errMap) == 0 {
+		return nil
+	}
+	err = fmt.Errorf("queryNamespaceMappings errors encountered")
+	for namespace, errStr := range errMap {
+		err = fmt.Errorf("%s, %s namespace had the following error: %s", err, namespace, errStr)
 	}
 
 	return err


### PR DESCRIPTION
Previously if any errors were encountered by queryNamespaceMappings, only a count of those errors was returned - making debugging those errors harder than it needs to be.

I'm changing this to immediately return nil if no errors are encountered, and otherwise an error will be formatted with each of the namespaces and what the error was for that namespace.

Additionally, if any errors were encountered during querySettings, they were potentially obscured by queryNamespaceMappings errors. I've added an immediate return if errors are found during querySettings to ensure these errors are visible.