### PR TITLE
[pg_stat_statements] Strip special characters from query

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `--collector.stat_statements.query_length`
   Maximum length of the statement text. Default is 120.
 
+* `--[no-]collector.stat_statements.strip_special`
+  Strip special characters like line breaks, carriage returns, tabs from query text. (default: disabled)
+
 * `[no-]collector.stat_user_tables`
   Enable the `stat_user_tables` collector (default: enabled).
 


### PR DESCRIPTION
Same queries from Windows and Linux clients to PostgreSQL may appear as different texts in `pg_stat_statements.query` having same query ID, because of different line breaks, which blocks proper matching `query` text to metrics with `queryid` label in Prometheus.
Example:
```
# Series from two replicas, one used by Windows client, another by Linux
$ curl -s 'http://prometheus.local:9090/api/v1/series?match[]=pg_stat_statements_query_id%7Bqueryid=%220000000000%22%7D' | jq .data.[].query 
"SELECT\r\n    "Username"\r\nFROM\r\n    \"Users\"\r\nWHERE\r\n        \"UserID\" = $1"
"SELECT\n    "Username"\nFROM\n    \"Users\"\nWHERE\n        \"UserID\" = $1"
```

This pull request adds option `--[no-]collector.stat_statements.strip_special` to remove such symbols from query output.

Authors:
@ussrlongbow
@freehck

