### PR TITLE
Exclude the metrics fetching session's data from pg_stat_activity

### DIFF
--- a/cmd/postgres_exporter/queries.go
+++ b/cmd/postgres_exporter/queries.go
@@ -142,6 +142,7 @@ var queryOverrides = map[string][]OverrideQuery{
 					count(*) AS count,
 					MAX(EXTRACT(EPOCH FROM now() - xact_start))::float AS max_tx_duration
 				FROM pg_stat_activity
+				WHERE pid <> pg_backend_pid()
 				GROUP BY datname,state,usename,application_name,backend_type,wait_event_type,wait_event) AS tmp2
 				ON tmp.state = tmp2.state AND pg_database.datname = tmp2.datname
 			`,
@@ -156,7 +157,9 @@ var queryOverrides = map[string][]OverrideQuery{
 				application_name,
 				COALESCE(count(*),0) AS count,
 				COALESCE(MAX(EXTRACT(EPOCH FROM now() - xact_start))::float,0) AS max_tx_duration
-			FROM pg_stat_activity GROUP BY datname,usename,application_name
+			FROM pg_stat_activity
+			WHERE procpid <> pg_backend_pid()
+			GROUP BY datname,usename,application_name
 			`,
 		},
 	},

--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -56,7 +56,8 @@ var (
 FROM pg_catalog.pg_stat_activity
 WHERE state IS DISTINCT FROM 'idle'
 AND query NOT LIKE 'autovacuum:%'
-AND pg_stat_activity.xact_start IS NOT NULL;
+AND pg_stat_activity.xact_start IS NOT NULL
+AND pid <> pg_backend_pid();
 	`
 )
 

--- a/collector/pg_process_idle.go
+++ b/collector/pg_process_idle.go
@@ -56,6 +56,7 @@ func (PGProcessIdleCollector) Update(ctx context.Context, instance *instance, ch
 				COUNT(*) AS process_idle_seconds_count
 				FROM pg_stat_activity
 				WHERE state ~ '^idle'
+				AND pid <> pg_backend_pid();
 				GROUP BY state, application_name
 			),
 			buckets AS (
@@ -72,6 +73,7 @@ func (PGProcessIdleCollector) Update(ctx context.Context, instance *instance, ch
 				FROM
 				pg_stat_activity,
 				UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
+				WHERE pid <> pg_backend_pid()
 				GROUP BY state, application_name, le
 				ORDER BY state, application_name, le
 			)


### PR DESCRIPTION
To reduce the observer effect, filter out pg_stat_activity rows of the postgres_exporter session from all SA queries, based on pid / procpid.

A bit annoying to see idling DBs showing pg_stat_activity_count "active" count of 1. Other Postgres monitoring tools (like [pgwatch](https://github.com/cybertec-postgresql/pgwatch/blob/master/internal/metrics/metrics.yaml#L59) for example) take it into account 