### PR TITLE
collector.wal: add pg_wal_lsn_location_bytes - WAL LSN bytes

### DIFF
--- a/collector/pg_wal.go
+++ b/collector/pg_wal.go
@@ -53,10 +53,26 @@ var (
 		[]string{}, nil,
 	)
 
+	pgWALLSNInBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(
+			namespace,
+			walSubsystem,
+			"lsn_location_bytes",
+		),
+		"WAL Log Sequence Number in bytes",
+		[]string{}, nil,
+	)
+
 	pgWALQuery = `
 		SELECT
 			COUNT(*) AS segments,
-			SUM(size) AS size
+			SUM(size) AS size,
+			(SELECT CASE
+			WHEN pg_is_in_recovery() THEN
+				pg_wal_lsn_diff(pg_last_wal_replay_lsn(), '0/0')::int8				
+			ELSE
+				pg_wal_lsn_diff(pg_current_wal_lsn(), '0/0')::int8
+			END) AS lsn_location_bytes
 		FROM pg_ls_waldir()
 		WHERE name ~ '^[0-9A-F]{24}$'`
 )
@@ -69,7 +85,8 @@ func (c PGWALCollector) Update(ctx context.Context, instance *instance, ch chan<
 
 	var segments uint64
 	var size sql.NullInt64
-	err := row.Scan(&segments, &size)
+	var lsnbytes uint64
+	err := row.Scan(&segments, &size, &lsnbytes)
 	if err != nil {
 		return err
 	}
@@ -81,6 +98,10 @@ func (c PGWALCollector) Update(ctx context.Context, instance *instance, ch chan<
 		ch <- prometheus.MustNewConstMetric(
 			pgWALSize,
 			prometheus.GaugeValue, float64(size.Int64),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			pgWALLSNInBytes,
+			prometheus.GaugeValue, float64(lsnbytes),
 		)
 	}
 	return nil

--- a/collector/pg_wal_test.go
+++ b/collector/pg_wal_test.go
@@ -31,9 +31,9 @@ func TestPgWALCollector(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	columns := []string{"segments", "size"}
+	columns := []string{"segments", "size", "lsn_location_bytes"}
 	rows := sqlmock.NewRows(columns).
-		AddRow(47, 788529152)
+		AddRow(47, 788529152, 123456789)
 	mock.ExpectQuery(sanitizeQuery(pgWALQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -49,6 +49,7 @@ func TestPgWALCollector(t *testing.T) {
 	expected := []MetricResult{
 		{labels: labelMap{}, value: 47, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{}, value: 788529152, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 123456789, metricType: dto.MetricType_GAUGE},
 	}
 
 	convey.Convey("Metrics comparison", t, func() {

--- a/collector/pg_wal_test.go
+++ b/collector/pg_wal_test.go
@@ -72,9 +72,9 @@ func TestPgWALCollectorZeroSegments(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	columns := []string{"segments", "size"}
+	columns := []string{"segments", "size", "lsn_location_bytes"}
 	rows := sqlmock.NewRows(columns).
-		AddRow(0, nil)
+		AddRow(0, nil, 0)
 	mock.ExpectQuery(sanitizeQuery(pgWALQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)


### PR DESCRIPTION
This is used commonly to monitor WAL writing intensity or rate in MB/s, an essential indicator basically for planning WAL archiving / RPO disk capacity.