### PR TITLE
Fix long_running_transactions query (#1066)

### DIFF
--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -54,6 +54,7 @@ var (
     MAX(EXTRACT(EPOCH FROM clock_timestamp() - pg_stat_activity.xact_start)) AS oldest_timestamp_seconds
 FROM pg_catalog.pg_stat_activity
 WHERE state IS DISTINCT FROM 'idle'
+AND (now() - pg_stat_activity.xact_start) > '1 minutes'::interval
 AND query NOT LIKE 'autovacuum:%'
 AND pg_stat_activity.xact_start IS NOT NULL
 AND pid <> pg_backend_pid();


### PR DESCRIPTION
Previously the query counted all transactions.

Without this, the metric doesn't really make any sense.

----

Tests still pass. The related test actually mocks the return value of the query so it doesn't test the query itself.