### PR TITLE
Add COALESCE with -1, to pg_stat_archiver query

### DIFF
--- a/cmd/postgres_exporter/queries.go
+++ b/cmd/postgres_exporter/queries.go
@@ -99,7 +99,7 @@ var queryOverrides = map[string][]OverrideQuery{
 			semver.MustParseRange(">=9.4.0"),
 			`
 			SELECT *,
-				extract(epoch from now() - last_archived_time) AS last_archive_age
+				COALESCE(extract(epoch from now() - last_archived_time), -1) AS last_archive_age
 			FROM pg_stat_archiver
 			`,
 		},


### PR DESCRIPTION
If coalesce is missing, null may be returned, and then NaN is returned to the prometheus metric. This is incorrect for the gauge type.