### PR TITLE
Fix: handle NULL values in pg_settings.short_desc for Postgres Pro Enterprise

### DIFF
--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -37,7 +37,7 @@ func querySettings(ch chan<- prometheus.Metric, server *Server) error {
 	//
 	// NOTE: If you add more vartypes here, you must update the supported
 	// types in normaliseUnit() below
-	query := "SELECT name, setting, COALESCE(unit, ''), short_desc, vartype FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real') AND name != 'sync_commit_cancel_wait';"
+	query := "SELECT name, setting, COALESCE(unit, ''), COALESCE(short_desc, '') AS short_desc, vartype FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real') AND name != 'sync_commit_cancel_wait';"
 
 	rows, err := server.db.Query(query)
 	if err != nil {


### PR DESCRIPTION
Fixes #1186

## Problem
Postgres Pro Enterprise 16.6 has NULL values in `pg_settings.short_desc` for parameters:
- replan_enable
- replan_show_signature

This causes exporter to crash with error: