### PR TITLE
feat: Add granted label pg_locks collector

### DIFF
--- a/collector/pg_locks_test.go
+++ b/collector/pg_locks_test.go
@@ -31,8 +31,8 @@ func TestPGLocksCollector(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	rows := sqlmock.NewRows([]string{"datname", "mode", "count"}).
-		AddRow("test", "exclusivelock", 42)
+	rows := sqlmock.NewRows([]string{"datname", "mode", "granted", "count"}).
+		AddRow("test", "exclusivelock", "true", 42)
 
 	mock.ExpectQuery(sanitizeQuery(pgLocksQuery)).WillReturnRows(rows)
 
@@ -46,7 +46,7 @@ func TestPGLocksCollector(t *testing.T) {
 	}()
 
 	expected := []MetricResult{
-		{labels: labelMap{"datname": "test", "mode": "exclusivelock"}, value: 42, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"datname": "test", "mode": "exclusivelock", "granted": "true"}, value: 42, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range expected {


### PR DESCRIPTION
Hi,

This PR adds `granted` label to `pg_locks_count` metric.

Implements and Closes #657.


## Implementation Choices:

**Postgres version compatibility**: I believe `pg_locks.granted` exists since postgres started to using Git. This is [the commit](https://github.com/postgres/postgres/commit/580fb7fb41414da359133a0342505dd3c9a7756a) that `src/backend/catalog/system_views.sql` file is added and `pg_locks.granted `exists at that time too. Nov 11 2003. Also in [7.3.0 release notes](https://www.postgresql.org/docs/release/7.3.0/ ) `pg_locks` is mentioned. So It'll be available since 7.3.0, because of these I did not use `instance.version.GE` like check, it's too old.

**Metric format**: I did not touch current format it'll be cartesian product, `value=0` will be exists. Only added `granted` label.

**How bool is implemented**: Since we already use data point's value for count of the current data point, like in below metric we know that there are 9 locks for `granted="true",mode="accesssharelock"`, I can't use the metric's value like [`pg_replication_slot_slot_is_active`](https://github.com/prometheus-community/postgres_exporter/blob/9e42fc0145a9d780d824d961afb7b70867558424/collector/pg_replication_slot.go#L58-L65), so used a new label called `granted`.
```promql
pg_locks_count{datname="postgres",granted="true",mode="accesssharelock"} 9`
```

Because we use count value I couldn't use [this standard](https://github.com/prometheus-community/postgres_exporter/blob/9e42fc0145a9d780d824d961afb7b70867558424/collector/pg_replication_slot.go#L58-L65). Found open-telemetry/opentelemetry-dotnet#4822 standard looks like using lowercase `"true" "false"` so used that.

**Cardinality and Metric Count**: Cardinality will be 2, just `granted="true|false"`. But metric count will be doubled because of the added 2 new dimension.


## Tests

**Unit Test**:

```bash
go test ./collector -run TestPGLocksCollector -v
=== RUN   TestPGLocksCollector

  Metrics comparison ✔


1 total assertion

--- PASS: TestPGLocksCollector (0.00s)
PASS
ok      github.com/prometheus-community/postgres_exporter/collector     (cached)
```

**Manual test**

Ran below:
```
CREATE DATABASE foo;
-- \c foo
CREATE TABLE foo(name text);

begin;
LOCK TABLE foo IN EXCLUSIVE MODE; 

-- In another session
begin;
LOCK TABLE foo IN EXCLUSIVE MODE; 
```

` curl -s http://localhost:9187/metrics  | grep pg_locks | grep foo`

<details>

<summary>Output</summary>


```promql
pg_locks_count{datname="foo",granted="false",mode="accessexclusivelock"} 0
pg_locks_count{datname="foo",granted="false",mode="accesssharelock"} 0
pg_locks_count{datname="foo",granted="false",mode="exclusivelock"} 1
pg_locks_count{datname="foo",granted="false",mode="rowexclusivelock"} 0
pg_locks_count{datname="foo",granted="false",mode="rowsharelock"} 0
pg_locks_count{datname="foo",granted="false",mode="sharelock"} 0
pg_locks_count{datname="foo",granted="false",mode="sharerowexclusivelock"} 0
pg_locks_count{datname="foo",granted="false",mode="shareupdateexclusivelock"} 0
pg_locks_count{datname="foo",granted="false",mode="sireadlock"} 0
pg_locks_count{datname="foo",granted="true",mode="accessexclusivelock"} 0
pg_locks_count{datname="foo",granted="true",mode="accesssharelock"} 0
pg_locks_count{datname="foo",granted="true",mode="exclusivelock"} 1
pg_locks_count{datname="foo",granted="true",mode="rowexclusivelock"} 0
pg_locks_count{datname="foo",granted="true",mode="rowsharelock"} 0
pg_locks_count{datname="foo",granted="true",mode="sharelock"} 0
pg_locks_count{datname="foo",granted="true",mode="sharerowexclusivelock"} 0
pg_locks_count{datname="foo",granted="true",mode="shareupdateexclusivelock"} 0
pg_locks_count{datname="foo",granted="true",mode="sireadlock"} 0
```
</details>