### PR TITLE
chore(Dashboard): Use default timepicker

### DIFF
--- a/postgres_mixin/dashboards/postgres-overview.json
+++ b/postgres_mixin/dashboards/postgres-overview.json
@@ -1429,32 +1429,6 @@
     "from": "now-1h",
     "to": "now"
   },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
-  "timezone": "browser",
   "title": "Postgres Overview",
   "uid": "wGgaPlciz",
   "version": 39,


### PR DESCRIPTION
Just use the system's default timepicker instead of hardcoding it.