### PR TITLE
fix: handle colon-delimited range in pg_settings (#1240)

### DIFF
--- a/exporter/pg_setting.go
+++ b/exporter/pg_setting.go
@@ -103,6 +103,9 @@ func (s *pgSetting) metric(labels prometheus.Labels) prometheus.Metric {
 // This is mostly because of a irregularity regarding AWS RDS Aurora
 // https://github.com/prometheus-community/postgres_exporter/issues/619
 func (s *pgSetting) sanitizeValue() {
+	if s.vartype == "integer" || s.vartype == "real" {
+		s.setting = strings.TrimPrefix(s.setting, "-1:")
+	}
 	for _, unit := range settingUnits {
 		if strings.HasSuffix(s.setting, unit) {
 			endPos := len(s.setting) - len(unit) - 1

--- a/exporter/pg_setting_test.go
+++ b/exporter/pg_setting_test.go
@@ -216,6 +216,22 @@ var fixtures = []fixture{
 			err:  `unknown unit for runtime variable: "nonexistent"`,
 		},
 	},
+	{
+		p: pgSetting{
+			name:      "max_messages",
+			setting:   "-1:172",
+			unit:      "s",
+			shortDesc: "Foo foo foo",
+			vartype:   "integer",
+		},
+		n: normalised{
+			val:  172,
+			unit: "seconds",
+			err:  "",
+		},
+		d: `Desc{fqName: "pg_settings_seconds_fixture_metric_seconds", help: "Server Parameter: seconds_fixture_metric [Units converted to seconds.]", constLabels: {}, variableLabels: {}}`,
+		v: 172,
+	},
 }
 
 func (s *PgSettingSuite) TestNormaliseUnit(c *C) {


### PR DESCRIPTION
The issue was caused by specific settings (notably google_dataplex.max_messages) returning values in a colon-delimited format (e.g., -1:100) which failed integer/real type conversion.