### PR TITLE
fix: Do not crash on bad pg_settings value

### DIFF
--- a/exporter/pg_setting.go
+++ b/exporter/pg_setting.go
@@ -51,8 +51,15 @@ func querySettings(ch chan<- prometheus.Metric, server *Server) error {
 		if err != nil {
 			return fmt.Errorf("Error retrieving rows on %q: %s %v", server, namespace, err)
 		}
-
-		ch <- s.metric(server.labels)
+		metric, err := s.metric(server.labels)
+		if err != nil {
+			// Log the error and continue
+			// This could be due to a bad value in the setting
+			// but we should not fail the entire scrape or panic
+			server.logger.Warn("Error normalising unit for setting", "setting", s.name, "value", s.setting, "unit", s.unit, "error", err)
+			continue
+		}
+		ch <- metric
 	}
 
 	return nil
@@ -64,7 +71,7 @@ type pgSetting struct {
 	name, setting, unit, shortDesc, vartype string
 }
 
-func (s *pgSetting) metric(labels prometheus.Labels) prometheus.Metric {
+func (s *pgSetting) metric(labels prometheus.Labels) (prometheus.Metric, error) {
 	var (
 		err       error
 		name      = strings.ReplaceAll(strings.ReplaceAll(s.name, ".", "_"), "-", "_")
@@ -81,9 +88,7 @@ func (s *pgSetting) metric(labels prometheus.Labels) prometheus.Metric {
 		}
 	case "integer", "real":
 		if val, unit, err = s.normaliseUnit(); err != nil {
-			// Panic, since we should recognise all units
-			// and don't want to silently exlude metrics
-			panic(err)
+			return nil, err
 		}
 
 		if len(unit) > 0 {
@@ -92,11 +97,11 @@ func (s *pgSetting) metric(labels prometheus.Labels) prometheus.Metric {
 		}
 	default:
 		// Panic because we got a type we didn't ask for
-		panic(fmt.Sprintf("Unsupported vartype %q", s.vartype))
+		return nil, fmt.Errorf("Unsupported vartype %q", s.vartype)
 	}
 
 	desc := newDesc(subsystem, name, shortDesc, labels)
-	return prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, val)
+	return prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, val), nil
 }
 
 // Removes units from any of the setting values.

--- a/exporter/pg_setting.go
+++ b/exporter/pg_setting.go
@@ -96,7 +96,6 @@ func (s *pgSetting) metric(labels prometheus.Labels) (prometheus.Metric, error) 
 			shortDesc = fmt.Sprintf("%s [Units converted to %s.]", shortDesc, unit)
 		}
 	default:
-		// Panic because we got a type we didn't ask for
 		return nil, fmt.Errorf("pgsetting: unsupported vartype %q", s.vartype)
 	}
 

--- a/exporter/pg_setting.go
+++ b/exporter/pg_setting.go
@@ -97,7 +97,7 @@ func (s *pgSetting) metric(labels prometheus.Labels) (prometheus.Metric, error) 
 		}
 	default:
 		// Panic because we got a type we didn't ask for
-		return nil, fmt.Errorf("Unsupported vartype %q", s.vartype)
+		return nil, fmt.Errorf("pgsetting: unsupported vartype %q", s.vartype)
 	}
 
 	desc := newDesc(subsystem, name, shortDesc, labels)

--- a/exporter/pg_setting_test.go
+++ b/exporter/pg_setting_test.go
@@ -237,17 +237,15 @@ func (s *PgSettingSuite) TestNormaliseUnit(c *C) {
 }
 
 func (s *PgSettingSuite) TestMetric(c *C) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r.(error).Error() != `unknown unit for runtime variable: "nonexistent"` {
-				panic(r)
-			}
-		}
-	}()
-
 	for _, f := range fixtures {
+		if f.n.err != "" {
+			continue
+		}
 		d := &dto.Metric{}
-		m := f.p.metric(prometheus.Labels{})
+		m, err := f.p.metric(prometheus.Labels{})
+		if err != nil {
+			c.Fatalf("Error creating metric: %v", err)
+		}
 		m.Write(d) // nolint: errcheck
 
 		c.Check(m.Desc().String(), Equals, f.d)


### PR DESCRIPTION
pg_settings metrics would panic when the parsing fails. This is a poor experience for users. An exporter should not panic. This skips unparsable metrics and instead logs a warning.

fixes #1240

These tests are weird, but I think that's a future PR as we refactor. 