### PR TITLE
chore: align go.mod go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.24.0
+go 1.25
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary

Update the Go version in `go.mod` from 1.24.0 to 1.25 to align with the CI build configuration.

## Motivation

The CI workflows (`.github/workflows/ci.yml`, `.github/workflows/golangci-lint.yml`) and build configuration (`.promu.yml`) already use Go 1.25, but `go.mod` was still specifying Go 1.24.0. This PR fixes the inconsistency.

## Changes

- Updated `go.mod` Go directive from `1.24.0` to `1.25`

## Testing

- `go mod tidy` runs without issues
- All unit tests pass