### PR TITLE
fix: ignore setting `google_dataplex.max_messages`

### DIFF
--- a/exporter/pg_setting.go
+++ b/exporter/pg_setting.go
@@ -37,6 +37,10 @@ func querySettings(ch chan<- prometheus.Metric, server *Server) error {
 	//
 	// NOTE: If you add more vartypes here, you must update the supported
 	// types in normaliseUnit() below
+	//
+	// Settings intentionally ignored due to invalid format:
+	// - `sync_commit_cancel_wait`, specific to Azure Postgres, see https://github.com/prometheus-community/postgres_exporter/issues/523
+	// - `google_dataplex.max_messages`, specific to Google Cloud SQL, see https://github.com/prometheus-community/postgres_exporter/issues/1240
 	query := "SELECT name, setting, COALESCE(unit, ''), short_desc, vartype FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real') AND name NOT IN ('sync_commit_cancel_wait', 'google_dataplex.max_messages');"
 
 	rows, err := server.db.Query(query)


### PR DESCRIPTION
Followup of https://github.com/prometheus-community/postgres_exporter/pull/1252

Ignore this setting altogether, as logging a warn at each scrape for a cloud provider specific entry seems a waste of resources.