### PR TITLE
fix: disable pg_settings scrape when --disable-default-metrics is set

### DIFF
--- a/exporter/datasource.go
+++ b/exporter/datasource.go
@@ -112,7 +112,7 @@ func (e *Exporter) scrapeDSN(ch chan<- prometheus.Metric, dsn string) error {
 		e.logger.Warn("Proceeding with outdated query maps, as the Postgres version could not be determined", "err", err)
 	}
 
-	return server.Scrape(ch, e.disableSettingsMetrics)
+	return server.Scrape(ch, e.disableSettingsMetrics || e.disableDefaultMetrics)
 }
 
 // try to get the DataSource


### PR DESCRIPTION
## Description

Fixes prometheus-community/postgres_exporter#712

When `--disable-default-metrics` is passed, users reasonably expect that **all** default metrics—including the `pg_settings` view—are skipped. Previously, only `--disable-settings-metrics` would suppress the `pg_settings` query; `--disable-default-metrics` had no effect on it.

This change makes `--disable-default-metrics` imply skipping pg_settings, by ORing the two flags when calling `server.Scrape`.

## Changes

- `exporter/datasource.go`: pass `e.disableSettingsMetrics || e.disableDefaultMetrics` to `server.Scrape` instead of just `e.disableSettingsMetrics`

## Testing

Existing unit tests pass. The bug was confirmed by users running with `--disable-default-metrics` and observing `Querying pg_setting view` debug lines in the logs.