### PR TITLE
Add sequence_overflow metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `[no-]collector.replication_slot`
   Enable the `replication_slot` collector (default: enabled).
 
+* `[no-]collector.sequence_overflow`
+  Enable the `sequence_overflow` collector (default: disabled).
+  Requires USAGE privilege on each sequence, or pg_read_all_data. Without it,
+  `pg_sequence_last_value()` returns NULL and all metrics will show 0.
+
 * `[no-]collector.stat_activity_autovacuum`
   Enable the `stat_activity_autovacuum` collector (default: disabled).
 

--- a/collector/pg_sequence_overflow.go
+++ b/collector/pg_sequence_overflow.go
@@ -1,0 +1,214 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"slices"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const sequenceOverflowSubsystem = "sequence_overflow"
+
+func init() {
+	registerCollector(sequenceOverflowSubsystem, defaultDisabled, NewPGSequenceOverflowCollector)
+}
+
+type PGSequenceOverflowCollector struct {
+	log               *slog.Logger
+	excludedDatabases []string
+}
+
+func NewPGSequenceOverflowCollector(config collectorConfig) (Collector, error) {
+	return &PGSequenceOverflowCollector{
+		log:               config.logger,
+		excludedDatabases: config.excludeDatabases,
+	}, nil
+}
+
+var (
+	sequenceOverflowLastValue = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, sequenceOverflowSubsystem, "last_value"),
+		"Last value consumed from the sequence.",
+		[]string{"datname", "schemaname", "sequence", "sequence_datatype", "owned_by", "column_datatype"},
+		prometheus.Labels{},
+	)
+	sequenceOverflowSequenceRatio = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, sequenceOverflowSubsystem, "sequence_ratio"),
+		"Ratio of the last sequence value to the maximum value of the sequence datatype (0–1).",
+		[]string{"datname", "schemaname", "sequence", "sequence_datatype", "owned_by", "column_datatype"},
+		prometheus.Labels{},
+	)
+	sequenceOverflowColumnRatio = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, sequenceOverflowSubsystem, "column_ratio"),
+		"Ratio of the last sequence value to the maximum value of the owning column datatype (0–1).",
+		[]string{"datname", "schemaname", "sequence", "sequence_datatype", "owned_by", "column_datatype"},
+		prometheus.Labels{},
+	)
+
+	sequenceOverflowDatabaseQuery = "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate;"
+
+	sequenceOverflowQuery = `
+SELECT
+    seqs.relname AS sequence,
+    format_type(s.seqtypid, NULL) AS sequence_datatype,
+    CONCAT(tbls.relname, '.', attrs.attname) AS owned_by,
+    format_type(attrs.atttypid, atttypmod) AS column_datatype,
+    ns.nspname AS schemaname,
+    COALESCE(pg_sequence_last_value(seqs.oid::regclass), 0) AS last_sequence_value,
+    COALESCE(CASE format_type(s.seqtypid, NULL)
+        WHEN 'smallint' THEN pg_sequence_last_value(seqs.oid::regclass) / 32767::float
+        WHEN 'integer'  THEN pg_sequence_last_value(seqs.oid::regclass) / 2147483647::float
+        WHEN 'bigint'   THEN pg_sequence_last_value(seqs.oid::regclass) / 9223372036854775807::float
+    END, 0) AS sequence_ratio,
+    COALESCE(CASE format_type(attrs.atttypid, NULL)
+        WHEN 'smallint' THEN pg_sequence_last_value(seqs.oid::regclass) / 32767::float
+        WHEN 'integer'  THEN pg_sequence_last_value(seqs.oid::regclass) / 2147483647::float
+        WHEN 'bigint'   THEN pg_sequence_last_value(seqs.oid::regclass) / 9223372036854775807::float
+    END, 0) AS column_ratio
+FROM pg_depend d
+JOIN pg_class AS seqs ON seqs.relkind = 'S' AND seqs.oid = d.objid
+JOIN pg_class AS tbls ON tbls.relkind = 'r' AND tbls.oid = d.refobjid
+JOIN pg_attribute AS attrs ON attrs.attrelid = d.refobjid AND attrs.attnum = d.refobjsubid
+JOIN pg_sequence s ON s.seqrelid = seqs.oid
+JOIN pg_namespace ns ON ns.oid = seqs.relnamespace
+WHERE d.deptype = 'a'
+  AND d.classid = 1259;
+`
+)
+
+// dsnForDatabase returns a new DSN with the database name replaced.
+// It updates both the URL path and the dbname query parameter (if present),
+// since libpq gives precedence to the query parameter over the path.
+func dsnForDatabase(dsn string, datname string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("could not parse DSN: %w", err)
+	}
+	u.Path = "/" + datname
+	if q := u.Query(); q.Get("dbname") != "" {
+		q.Set("dbname", datname)
+		u.RawQuery = q.Encode()
+	}
+	return u.String(), nil
+}
+
+// Update implements Collector and exposes sequence integer overflow metrics
+// for all non-template databases on the instance.
+// It is called by the Prometheus registry when collecting metrics.
+// Note: pg_sequence_last_value requires USAGE privilege on each sequence,
+// or pg_read_all_data. Without it the function returns NULL, which COALESCE converts
+// to 0, causing all metrics to show 0 with no visible error.
+func (c *PGSequenceOverflowCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+	db := instance.getDB()
+
+	// Fetch the list of connectable, non-template databases.
+	rows, err := db.QueryContext(ctx, sequenceOverflowDatabaseQuery)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var databases []string
+	for rows.Next() {
+		var datname sql.NullString
+		if err := rows.Scan(&datname); err != nil {
+			return err
+		}
+		if !datname.Valid {
+			continue
+		}
+		if slices.Contains(c.excludedDatabases, datname.String) {
+			continue
+		}
+		databases = append(databases, datname.String)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// Query sequence metrics from each database individually.
+	for _, datname := range databases {
+		newDSN, err := dsnForDatabase(instance.dsn, datname)
+		if err != nil {
+			c.log.Debug("Skipping database", "datname", datname, "err", err)
+			continue
+		}
+		dbConn, err := sql.Open("postgres", newDSN)
+		if err != nil {
+			c.log.Debug("Skipping database", "datname", datname, "err", err)
+			continue
+		}
+		if err := c.updateDatabase(ctx, dbConn, datname, ch); err != nil {
+			c.log.Debug("Skipping database", "datname", datname, "err", err)
+		}
+		dbConn.Close()
+	}
+	return nil
+}
+
+func (c *PGSequenceOverflowCollector) updateDatabase(ctx context.Context, db *sql.DB, datname string, ch chan<- prometheus.Metric) error {
+	rows, err := db.QueryContext(ctx, sequenceOverflowQuery)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		// sequence_datatype, owned_by, and column_datatype are sourced from NOT NULL
+		// catalog columns (seqtypid, relname/attname, atttypid) and cannot be NULL
+		// given the JOIN structure.
+		var sequence, sequenceDatatype, ownedBy, columnDatatype, schemaname sql.NullString
+		var lastValue, sequenceRatio, columnRatio float64
+
+		if err := rows.Scan(&sequence, &sequenceDatatype, &ownedBy, &columnDatatype, &schemaname, &lastValue, &sequenceRatio, &columnRatio); err != nil {
+			return err
+		}
+
+		if !sequence.Valid {
+			c.log.Debug("Skipping sequence with NULL name", "datname", datname)
+			continue
+		}
+
+		schemanameLabel := "unknown"
+		if schemaname.Valid {
+			schemanameLabel = schemaname.String
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			sequenceOverflowLastValue,
+			prometheus.GaugeValue,
+			lastValue,
+			datname, schemanameLabel, sequence.String, sequenceDatatype.String, ownedBy.String, columnDatatype.String,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			sequenceOverflowSequenceRatio,
+			prometheus.GaugeValue,
+			sequenceRatio,
+			datname, schemanameLabel, sequence.String, sequenceDatatype.String, ownedBy.String, columnDatatype.String,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			sequenceOverflowColumnRatio,
+			prometheus.GaugeValue,
+			columnRatio,
+			datname, schemanameLabel, sequence.String, sequenceDatatype.String, ownedBy.String, columnDatatype.String,
+		)
+	}
+	return rows.Err()
+}

--- a/collector/pg_sequence_overflow_test.go
+++ b/collector/pg_sequence_overflow_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestPGSequenceOverflowCollector(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening a stub db connection: %s", err)
+	}
+	defer db.Close()
+
+	seqColumns := []string{
+		"sequence",
+		"sequence_datatype",
+		"owned_by",
+		"column_datatype",
+		"schemaname",
+		"last_sequence_value",
+		"sequence_ratio",
+		"column_ratio",
+	}
+
+	// Row 1: integer sequence on an integer column, 50% consumed.
+	// Row 2: bigint sequence on an integer column — sequence type has far more
+	// headroom than the column type, so sequence_ratio is near 0 while column_ratio is 0.5.
+	rows := sqlmock.NewRows(seqColumns).
+		AddRow("my_table_id_seq", "integer", "my_table.id", "integer", "public", 1073741823, 0.5, 0.5).
+		AddRow("other_table_id_seq", "bigint", "other_table.id", "integer", "public", 1073741823, 0.25, 0.5)
+
+	mock.ExpectQuery(sanitizeQuery(sequenceOverflowQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		c := PGSequenceOverflowCollector{}
+		if err := c.updateDatabase(context.Background(), db, "mydb", ch); err != nil {
+			t.Errorf("Error calling updateDatabase: %s", err)
+		}
+	}()
+
+	labels1 := labelMap{
+		"datname":           "mydb",
+		"schemaname":        "public",
+		"sequence":          "my_table_id_seq",
+		"sequence_datatype": "integer",
+		"owned_by":          "my_table.id",
+		"column_datatype":   "integer",
+	}
+	labels2 := labelMap{
+		"datname":           "mydb",
+		"schemaname":        "public",
+		"sequence":          "other_table_id_seq",
+		"sequence_datatype": "bigint",
+		"owned_by":          "other_table.id",
+		"column_datatype":   "integer",
+	}
+
+	expected := []MetricResult{
+		{labels: labels1, value: 1073741823, metricType: dto.MetricType_GAUGE},
+		{labels: labels1, value: 0.5, metricType: dto.MetricType_GAUGE},
+		{labels: labels1, value: 0.5, metricType: dto.MetricType_GAUGE},
+		{labels: labels2, value: 1073741823, metricType: dto.MetricType_GAUGE},
+		{labels: labels2, value: 0.25, metricType: dto.MetricType_GAUGE},
+		{labels: labels2, value: 0.5, metricType: dto.MetricType_GAUGE},
+	}
+
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			m := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, m)
+		}
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}
+
+func TestPGSequenceOverflowCollectorNullValues(t *testing.T) {
+	// Sequences that have never been used: COALESCE in the query converts NULL
+	// from pg_sequence_last_value to 0, so all numeric columns return 0.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening a stub db connection: %s", err)
+	}
+	defer db.Close()
+
+	seqColumns := []string{
+		"sequence",
+		"sequence_datatype",
+		"owned_by",
+		"column_datatype",
+		"schemaname",
+		"last_sequence_value",
+		"sequence_ratio",
+		"column_ratio",
+	}
+
+	rows := sqlmock.NewRows(seqColumns).
+		AddRow("unused_seq", "integer", "some_table.id", "integer", "public", 0, 0, 0)
+
+	mock.ExpectQuery(sanitizeQuery(sequenceOverflowQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		c := PGSequenceOverflowCollector{}
+		if err := c.updateDatabase(context.Background(), db, "mydb", ch); err != nil {
+			t.Errorf("Error calling updateDatabase: %s", err)
+		}
+	}()
+
+	labels := labelMap{
+		"datname":           "mydb",
+		"schemaname":        "public",
+		"sequence":          "unused_seq",
+		"sequence_datatype": "integer",
+		"owned_by":          "some_table.id",
+		"column_datatype":   "integer",
+	}
+
+	expected := []MetricResult{
+		{labels: labels, value: 0, metricType: dto.MetricType_GAUGE},
+		{labels: labels, value: 0, metricType: dto.MetricType_GAUGE},
+		{labels: labels, value: 0, metricType: dto.MetricType_GAUGE},
+	}
+
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			m := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, m)
+		}
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}


### PR DESCRIPTION
This query was based on

https://www.crunchydata.com/blog/the-integer-at-the-end-of-the-universe-integer-overflow-in-postgres

and exposes metrics for % used for the underlying column type.

This requires usage on all sequences, or `GRANT pg_read_all_data TO postgres_exporter;`

pg_read_all_data is a bit excessive, but granting usage on all sequences won't apply for new sequences that are added, and setting default privileges for schemas won't apply if new schemas are added.

```text
pg_sequence_overflow_column_ratio{column_datatype="bigint", datname="mydb", instance="mydb.example.com", job="postgres-exporter", owned_by="my_table.id", schemaname="public", sequence="my_table_id_seq", sequence_datatype="bigint"}
	8.745220514546834e-10
pg_sequence_overflow_last_value{column_datatype="bigint", datname="mydb", instance="mydb.example.com", job="postgres-exporter", owned_by="my_table.id", region="dal", schemaname="public", sequence="my_table_id_seq", sequence_datatype="bigint"}
	8066042235
pg_sequence_overflow_sequence_ratio{column_datatype="bigint", datname="mydb", instance="mydb.example.com", job="postgres-exporter", owned_by="my_table.id", schemaname="public", sequence="my_table_id_seq", sequence_datatype="bigint"}
	8.745220514546834e-10
```