### PR TITLE
Remove global auth config reload metrics

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -35,9 +35,7 @@ import (
 )
 
 var (
-	c = config.Handler{
-		Config: &config.Config{},
-	}
+	c = newConfigHandler()
 
 	configFile             = kingpin.Flag("config.file", "Postgres exporter configuration file.").Default("postgres_exporter.yml").String()
 	webConfig              = kingpinflag.AddFlags(kingpin.CommandLine, ":9187")
@@ -57,6 +55,14 @@ var (
 
 // The name of the exporter.
 const exporterName = "postgres_exporter"
+
+func newConfigHandler() *config.Handler {
+	handler, err := config.NewHandler(prometheus.DefaultRegisterer)
+	if err != nil {
+		panic(err)
+	}
+	return handler
+}
 
 func main() {
 	kingpin.Version(version.Print(exporterName))

--- a/config/config.go
+++ b/config/config.go
@@ -14,28 +14,15 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gopkg.in/yaml.v3"
-)
-
-var (
-	configReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "postgres_exporter",
-		Name:      "config_last_reload_successful",
-		Help:      "Postgres exporter config loaded successfully.",
-	})
-
-	configReloadSeconds = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "postgres_exporter",
-		Name:      "config_last_reload_success_timestamp_seconds",
-		Help:      "Timestamp of the last successful configuration reload.",
-	})
 )
 
 type Config struct {
@@ -57,6 +44,31 @@ type UserPass struct {
 type Handler struct {
 	sync.RWMutex
 	Config *Config
+
+	configReloadSuccess prometheus.Gauge
+	configReloadSeconds prometheus.Gauge
+}
+
+func NewHandler(registerer prometheus.Registerer) (*Handler, error) {
+	if registerer == nil {
+		return nil, errors.New("registerer is required")
+	}
+	h := &Handler{
+		Config: &Config{},
+		configReloadSuccess: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "postgres_exporter",
+			Name:      "config_last_reload_successful",
+			Help:      "Postgres exporter config loaded successfully.",
+		}),
+		configReloadSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "postgres_exporter",
+			Name:      "config_last_reload_success_timestamp_seconds",
+			Help:      "Timestamp of the last successful configuration reload.",
+		}),
+	}
+	registerer.MustRegister(h.configReloadSuccess, h.configReloadSeconds)
+
+	return h, nil
 }
 
 func (ch *Handler) GetConfig() *Config {
@@ -66,33 +78,63 @@ func (ch *Handler) GetConfig() *Config {
 }
 
 func (ch *Handler) ReloadConfig(f string, logger *slog.Logger) error {
-	config := &Config{}
 	var err error
 	defer func() {
-		if err != nil {
-			configReloadSuccess.Set(0)
-		} else {
-			configReloadSuccess.Set(1)
-			configReloadSeconds.SetToCurrentTime()
-		}
+		ch.observeReload(err)
 	}()
 
+	config, err := LoadConfig(f)
+	if err != nil {
+		return err
+	}
+
+	ch.SetConfig(config)
+	return nil
+}
+
+func (ch *Handler) observeReload(err error) {
+	if ch.configReloadSuccess == nil {
+		return
+	}
+	if err != nil {
+		ch.configReloadSuccess.Set(0)
+		return
+	}
+	ch.configReloadSuccess.Set(1)
+	if ch.configReloadSeconds != nil {
+		ch.configReloadSeconds.SetToCurrentTime()
+	}
+}
+
+func LoadConfig(f string) (*Config, error) {
 	yamlReader, err := os.Open(f)
 	if err != nil {
-		return fmt.Errorf("error opening config file %q: %s", f, err)
+		return nil, fmt.Errorf("error opening config file %q: %s", f, err)
 	}
 	defer yamlReader.Close()
-	decoder := yaml.NewDecoder(yamlReader)
+
+	config, err := DecodeConfig(yamlReader)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing config file %q: %s", f, err)
+	}
+	return config, nil
+}
+
+func DecodeConfig(r io.Reader) (*Config, error) {
+	config := &Config{}
+	decoder := yaml.NewDecoder(r)
 	decoder.KnownFields(true)
 
-	if err = decoder.Decode(config); err != nil {
-		return fmt.Errorf("error parsing config file %q: %s", f, err)
+	if err := decoder.Decode(config); err != nil {
+		return nil, err
 	}
+	return config, nil
+}
 
+func (ch *Handler) SetConfig(config *Config) {
 	ch.Lock()
 	ch.Config = config
 	ch.Unlock()
-	return nil
 }
 
 func (m AuthModule) ConfigureTarget(target string) (DSN, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,23 +14,64 @@
 package config
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
+func TestLoadConfigFile(t *testing.T) {
+	config, err := LoadConfig("testdata/config-good.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if len(config.AuthModules) == 0 {
+		t.Fatal("LoadConfig() loaded no auth modules")
+	}
+}
+
+func TestDecodeConfig(t *testing.T) {
+	config, err := DecodeConfig(strings.NewReader(`
+auth_modules:
+  module:
+    type: userpass
+    userpass:
+      username: user
+      password: pass
+`))
+	if err != nil {
+		t.Fatalf("DecodeConfig() error = %v", err)
+	}
+	if got, want := config.AuthModules["module"].UserPass.Username, "user"; got != want {
+		t.Fatalf("username = %q, want %q", got, want)
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
-	ch := &Handler{
-		Config: &Config{},
+	ch, err := NewHandler(prometheus.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
 	}
 
-	err := ch.ReloadConfig("testdata/config-good.yaml", nil)
-	if err != nil {
+	if err := ch.ReloadConfig("testdata/config-good.yaml", nil); err != nil {
 		t.Errorf("error loading config: %s", err)
 	}
 }
 
+func TestNewHandlerRequiresRegisterer(t *testing.T) {
+	handler, err := NewHandler(nil)
+	if err == nil {
+		t.Fatal("NewHandler() error = nil, want error")
+	}
+	if handler != nil {
+		t.Fatalf("NewHandler() handler = %v, want nil", handler)
+	}
+}
+
 func TestLoadBadConfigs(t *testing.T) {
-	ch := &Handler{
-		Config: &Config{},
+	ch, err := NewHandler(prometheus.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
 	}
 
 	tests := []struct {


### PR DESCRIPTION
This change separates the exporter auth configuration from the runtime handler that reloads it and observes reload metrics.

It removes the auth reload metrics from `promauto`-style global registration. Instead, each auth config handler creates and registers its own reload metrics with a caller-provided registerer. 

The exporter binary still uses an auth config handler, so existing reload behavior is preserved. The important change is that auth config data, auth config loading, reload state, and reload metric registration are no longer collapsed into one global-ish abstraction. The exporter binary also continues to use the Global Default Registerer