### PR TITLE
Rename auth config APIs

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -35,9 +35,7 @@ import (
 )
 
 var (
-	c = config.Handler{
-		Config: &config.Config{},
-	}
+	c = newConfigHandler()
 
 	configFile             = kingpin.Flag("config.file", "Postgres exporter configuration file.").Default("postgres_exporter.yml").String()
 	webConfig              = kingpinflag.AddFlags(kingpin.CommandLine, ":9187")
@@ -57,6 +55,14 @@ var (
 
 // The name of the exporter.
 const exporterName = "postgres_exporter"
+
+func newConfigHandler() *config.Handler {
+	handler, err := config.NewHandler(prometheus.DefaultRegisterer)
+	if err != nil {
+		panic(err)
+	}
+	return handler
+}
 
 func main() {
 	kingpin.Version(version.Print(exporterName))

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	c = newConfigHandler()
+	c = newAuthConfigHandler()
 
 	configFile             = kingpin.Flag("config.file", "Postgres exporter configuration file.").Default("postgres_exporter.yml").String()
 	webConfig              = kingpinflag.AddFlags(kingpin.CommandLine, ":9187")
@@ -56,8 +56,8 @@ var (
 // The name of the exporter.
 const exporterName = "postgres_exporter"
 
-func newConfigHandler() *config.Handler {
-	handler, err := config.NewHandler(prometheus.DefaultRegisterer)
+func newAuthConfigHandler() *config.AuthConfigHandler {
+	handler, err := config.NewAuthConfigHandler(prometheus.DefaultRegisterer)
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +77,7 @@ func main() {
 		return
 	}
 
-	if err := c.ReloadConfig(*configFile, logger); err != nil {
+	if err := c.ReloadAuthConfig(*configFile, logger); err != nil {
 		// This is not fatal, but it means that auth must be provided for every dsn.
 		logger.Warn("Error loading config", "err", err)
 	}

--- a/cmd/postgres_exporter/probe.go
+++ b/cmd/postgres_exporter/probe.go
@@ -28,7 +28,7 @@ import (
 func handleProbe(logger *slog.Logger, excludeDatabases []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		conf := c.GetConfig()
+		conf := c.GetAuthConfig()
 		params := r.URL.Query()
 		target := params.Get("target")
 		if target == "" {

--- a/config/auth.go
+++ b/config/auth.go
@@ -25,7 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type Config struct {
+type AuthConfig struct {
 	AuthModules map[string]AuthModule `yaml:"auth_modules"`
 }
 
@@ -41,20 +41,20 @@ type UserPass struct {
 	Password string `yaml:"password"`
 }
 
-type Handler struct {
+type AuthConfigHandler struct {
 	sync.RWMutex
-	Config *Config
+	AuthConfig *AuthConfig
 
 	configReloadSuccess prometheus.Gauge
 	configReloadSeconds prometheus.Gauge
 }
 
-func NewHandler(registerer prometheus.Registerer) (*Handler, error) {
+func NewAuthConfigHandler(registerer prometheus.Registerer) (*AuthConfigHandler, error) {
 	if registerer == nil {
 		return nil, errors.New("registerer is required")
 	}
-	h := &Handler{
-		Config: &Config{},
+	h := &AuthConfigHandler{
+		AuthConfig: &AuthConfig{},
 		configReloadSuccess: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "postgres_exporter",
 			Name:      "config_last_reload_successful",
@@ -71,28 +71,28 @@ func NewHandler(registerer prometheus.Registerer) (*Handler, error) {
 	return h, nil
 }
 
-func (ch *Handler) GetConfig() *Config {
+func (ch *AuthConfigHandler) GetAuthConfig() *AuthConfig {
 	ch.RLock()
 	defer ch.RUnlock()
-	return ch.Config
+	return ch.AuthConfig
 }
 
-func (ch *Handler) ReloadConfig(f string, logger *slog.Logger) error {
+func (ch *AuthConfigHandler) ReloadAuthConfig(f string, logger *slog.Logger) error {
 	var err error
 	defer func() {
 		ch.observeReload(err)
 	}()
 
-	config, err := LoadConfig(f)
+	config, err := LoadAuthConfig(f)
 	if err != nil {
 		return err
 	}
 
-	ch.SetConfig(config)
+	ch.SetAuthConfig(config)
 	return nil
 }
 
-func (ch *Handler) observeReload(err error) {
+func (ch *AuthConfigHandler) observeReload(err error) {
 	if ch.configReloadSuccess == nil {
 		return
 	}
@@ -106,22 +106,22 @@ func (ch *Handler) observeReload(err error) {
 	}
 }
 
-func LoadConfig(f string) (*Config, error) {
+func LoadAuthConfig(f string) (*AuthConfig, error) {
 	yamlReader, err := os.Open(f)
 	if err != nil {
 		return nil, fmt.Errorf("error opening config file %q: %s", f, err)
 	}
 	defer yamlReader.Close()
 
-	config, err := DecodeConfig(yamlReader)
+	config, err := DecodeAuthConfig(yamlReader)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing config file %q: %s", f, err)
 	}
 	return config, nil
 }
 
-func DecodeConfig(r io.Reader) (*Config, error) {
-	config := &Config{}
+func DecodeAuthConfig(r io.Reader) (*AuthConfig, error) {
+	config := &AuthConfig{}
 	decoder := yaml.NewDecoder(r)
 	decoder.KnownFields(true)
 
@@ -131,9 +131,9 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 	return config, nil
 }
 
-func (ch *Handler) SetConfig(config *Config) {
+func (ch *AuthConfigHandler) SetAuthConfig(config *AuthConfig) {
 	ch.Lock()
-	ch.Config = config
+	ch.AuthConfig = config
 	ch.Unlock()
 }
 

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -20,18 +20,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func TestLoadConfigFile(t *testing.T) {
-	config, err := LoadConfig("testdata/config-good.yaml")
+func TestLoadAuthConfig(t *testing.T) {
+	config, err := LoadAuthConfig("testdata/config-good.yaml")
 	if err != nil {
-		t.Fatalf("LoadConfig() error = %v", err)
+		t.Fatalf("LoadAuthConfig() error = %v", err)
 	}
 	if len(config.AuthModules) == 0 {
-		t.Fatal("LoadConfig() loaded no auth modules")
+		t.Fatal("LoadAuthConfig() loaded no auth modules")
 	}
 }
 
-func TestDecodeConfig(t *testing.T) {
-	config, err := DecodeConfig(strings.NewReader(`
+func TestDecodeAuthConfig(t *testing.T) {
+	config, err := DecodeAuthConfig(strings.NewReader(`
 auth_modules:
   module:
     type: userpass
@@ -40,38 +40,38 @@ auth_modules:
       password: pass
 `))
 	if err != nil {
-		t.Fatalf("DecodeConfig() error = %v", err)
+		t.Fatalf("DecodeAuthConfig() error = %v", err)
 	}
 	if got, want := config.AuthModules["module"].UserPass.Username, "user"; got != want {
 		t.Fatalf("username = %q, want %q", got, want)
 	}
 }
 
-func TestLoadConfig(t *testing.T) {
-	ch, err := NewHandler(prometheus.NewRegistry())
+func TestLoadAuthConfigWithHandler(t *testing.T) {
+	ch, err := NewAuthConfigHandler(prometheus.NewRegistry())
 	if err != nil {
-		t.Fatalf("NewHandler() error = %v", err)
+		t.Fatalf("NewAuthConfigHandler() error = %v", err)
 	}
 
-	if err := ch.ReloadConfig("testdata/config-good.yaml", nil); err != nil {
-		t.Errorf("error loading config: %s", err)
+	if err := ch.ReloadAuthConfig("testdata/config-good.yaml", nil); err != nil {
+		t.Errorf("error loading auth config: %s", err)
 	}
 }
 
-func TestNewHandlerRequiresRegisterer(t *testing.T) {
-	handler, err := NewHandler(nil)
+func TestNewAuthConfigHandlerRequiresRegisterer(t *testing.T) {
+	handler, err := NewAuthConfigHandler(nil)
 	if err == nil {
-		t.Fatal("NewHandler() error = nil, want error")
+		t.Fatal("NewAuthConfigHandler() error = nil, want error")
 	}
 	if handler != nil {
-		t.Fatalf("NewHandler() handler = %v, want nil", handler)
+		t.Fatalf("NewAuthConfigHandler() handler = %v, want nil", handler)
 	}
 }
 
 func TestLoadBadConfigs(t *testing.T) {
-	ch, err := NewHandler(prometheus.NewRegistry())
+	ch, err := NewAuthConfigHandler(prometheus.NewRegistry())
 	if err != nil {
-		t.Fatalf("NewHandler() error = %v", err)
+		t.Fatalf("NewAuthConfigHandler() error = %v", err)
 	}
 
 	tests := []struct {
@@ -90,9 +90,9 @@ func TestLoadBadConfigs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			got := ch.ReloadConfig(test.input, nil)
+			got := ch.ReloadAuthConfig(test.input, nil)
 			if got == nil || got.Error() != test.want {
-				t.Fatalf("ReloadConfig(%q) = %v, want %s", test.input, got, test.want)
+				t.Fatalf("ReloadAuthConfig(%q) = %v, want %s", test.input, got, test.want)
 			}
 		})
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -14,28 +14,15 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gopkg.in/yaml.v3"
-)
-
-var (
-	configReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "postgres_exporter",
-		Name:      "config_last_reload_successful",
-		Help:      "Postgres exporter config loaded successfully.",
-	})
-
-	configReloadSeconds = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "postgres_exporter",
-		Name:      "config_last_reload_success_timestamp_seconds",
-		Help:      "Timestamp of the last successful configuration reload.",
-	})
 )
 
 type Config struct {
@@ -57,6 +44,31 @@ type UserPass struct {
 type Handler struct {
 	sync.RWMutex
 	Config *Config
+
+	configReloadSuccess prometheus.Gauge
+	configReloadSeconds prometheus.Gauge
+}
+
+func NewHandler(registerer prometheus.Registerer) (*Handler, error) {
+	if registerer == nil {
+		return nil, errors.New("registerer is required")
+	}
+	h := &Handler{
+		Config: &Config{},
+		configReloadSuccess: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "postgres_exporter",
+			Name:      "config_last_reload_successful",
+			Help:      "Postgres exporter config loaded successfully.",
+		}),
+		configReloadSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "postgres_exporter",
+			Name:      "config_last_reload_success_timestamp_seconds",
+			Help:      "Timestamp of the last successful configuration reload.",
+		}),
+	}
+	registerer.MustRegister(h.configReloadSuccess, h.configReloadSeconds)
+
+	return h, nil
 }
 
 func (ch *Handler) GetConfig() *Config {
@@ -66,33 +78,63 @@ func (ch *Handler) GetConfig() *Config {
 }
 
 func (ch *Handler) ReloadConfig(f string, logger *slog.Logger) error {
-	config := &Config{}
 	var err error
 	defer func() {
-		if err != nil {
-			configReloadSuccess.Set(0)
-		} else {
-			configReloadSuccess.Set(1)
-			configReloadSeconds.SetToCurrentTime()
-		}
+		ch.observeReload(err)
 	}()
 
+	config, err := LoadConfig(f)
+	if err != nil {
+		return err
+	}
+
+	ch.SetConfig(config)
+	return nil
+}
+
+func (ch *Handler) observeReload(err error) {
+	if ch.configReloadSuccess == nil {
+		return
+	}
+	if err != nil {
+		ch.configReloadSuccess.Set(0)
+		return
+	}
+	ch.configReloadSuccess.Set(1)
+	if ch.configReloadSeconds != nil {
+		ch.configReloadSeconds.SetToCurrentTime()
+	}
+}
+
+func LoadConfig(f string) (*Config, error) {
 	yamlReader, err := os.Open(f)
 	if err != nil {
-		return fmt.Errorf("error opening config file %q: %s", f, err)
+		return nil, fmt.Errorf("error opening config file %q: %s", f, err)
 	}
 	defer yamlReader.Close()
-	decoder := yaml.NewDecoder(yamlReader)
+
+	config, err := DecodeConfig(yamlReader)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing config file %q: %s", f, err)
+	}
+	return config, nil
+}
+
+func DecodeConfig(r io.Reader) (*Config, error) {
+	config := &Config{}
+	decoder := yaml.NewDecoder(r)
 	decoder.KnownFields(true)
 
-	if err = decoder.Decode(config); err != nil {
-		return fmt.Errorf("error parsing config file %q: %s", f, err)
+	if err := decoder.Decode(config); err != nil {
+		return nil, err
 	}
+	return config, nil
+}
 
+func (ch *Handler) SetConfig(config *Config) {
 	ch.Lock()
 	ch.Config = config
 	ch.Unlock()
-	return nil
 }
 
 func (m AuthModule) ConfigureTarget(target string) (DSN, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,23 +14,64 @@
 package config
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
+func TestLoadConfigFile(t *testing.T) {
+	config, err := LoadConfig("testdata/config-good.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if len(config.AuthModules) == 0 {
+		t.Fatal("LoadConfig() loaded no auth modules")
+	}
+}
+
+func TestDecodeConfig(t *testing.T) {
+	config, err := DecodeConfig(strings.NewReader(`
+auth_modules:
+  module:
+    type: userpass
+    userpass:
+      username: user
+      password: pass
+`))
+	if err != nil {
+		t.Fatalf("DecodeConfig() error = %v", err)
+	}
+	if got, want := config.AuthModules["module"].UserPass.Username, "user"; got != want {
+		t.Fatalf("username = %q, want %q", got, want)
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
-	ch := &Handler{
-		Config: &Config{},
+	ch, err := NewHandler(prometheus.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
 	}
 
-	err := ch.ReloadConfig("testdata/config-good.yaml", nil)
-	if err != nil {
+	if err := ch.ReloadConfig("testdata/config-good.yaml", nil); err != nil {
 		t.Errorf("error loading config: %s", err)
 	}
 }
 
+func TestNewHandlerRequiresRegisterer(t *testing.T) {
+	handler, err := NewHandler(nil)
+	if err == nil {
+		t.Fatal("NewHandler() error = nil, want error")
+	}
+	if handler != nil {
+		t.Fatalf("NewHandler() handler = %v, want nil", handler)
+	}
+}
+
 func TestLoadBadConfigs(t *testing.T) {
-	ch := &Handler{
-		Config: &Config{},
+	ch, err := NewHandler(prometheus.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
 	}
 
 	tests := []struct {


### PR DESCRIPTION
This PR builds on https://github.com/prometheus-community/postgres_exporter/pull/1296; it just renames the `Config` API to `AuthConfig` since it only covers Auth.

The reason I'm making this change is that I want `Config` to be a broader struct. `Config` should hold all the configuration options that we currently implement as CLI flags. The postgres_exporter will continue to implement this new `Config` struct using CLI/Env vars, but it will also allow downstream projects to implement the same struct using other strategies, such as Go Tags, YAML deserializers, or any other approach that might be needed.