### PR TITLE
security: Update Go to 1.25.8 to fix CVE-2026-25679

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
 ## Summary
Updates the Go version from 1.25.0 to 1.25.8 to address **CVE-2026-25679**, a HIGH severity security vulnerability in Go's standard library.
 
 ## Vulnerability Details                                                                    
  - **CVE ID**: CVE-2026-25679                                                               
  - **Severity**: HIGH (CVSS 7.5)
  - **Component**: Go stdlib `net/url` package                                             
  - **Issue**: `url.Parse` insufficiently validated the host/authority component and accepted some invalid URLs
  - **Published**: March 6, 2026                                                           
                                                                                             
## Affected Versions                                                                                                                                                                  
All Go versions prior to 1.25.8 are vulnerable, including Go 1.25.0 currently used in this project.
                                                                                             
## Fix                                                                                      
This PR updates `go.mod` to use Go 1.25.8, which includes the security patch for CVE-2026-25679.