### PR TITLE
feat: Add probe target allowlist for /probe (SSRF and DNS rebinding hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ To use the multi-target functionality, send an http request to the endpoint `/pr
 
 To avoid putting sensitive information like username and password in the URL, preconfigured auth modules are supported via the [auth_modules](#auth_modules) section of the config file. auth_modules for DSNs can be used with the `/probe` endpoint by specifying the `?auth_module=foo` http parameter.
 
+For additional hardening, `/probe` targets can be restricted with `--probe-target-allowlist` (or `PG_EXPORTER_PROBE_TARGET_ALLOWLIST`). The allowlist accepts comma-separated `CIDR` and `host:port` entries. By default this setting is empty, which preserves existing behavior and allows all probe targets.
+
 Example Prometheus config:
 ```yaml
 scrape_configs:
@@ -208,6 +210,9 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `disable-settings-metrics`
   Use the flag if you don't want to scrape `pg_settings`.  Default is `false`.
 
+* `probe-target-allowlist`
+  Optional comma-separated allowlist for `/probe` target values. Entries support `CIDR` and `host:port`. Default is empty (allow all targets).
+
 * `auto-discover-databases` (DEPRECATED)
   Whether to discover the databases on a server dynamically.  Default is `false`.
 
@@ -283,6 +288,9 @@ The following environment variables configure the exporter:
 
 * `PG_EXPORTER_DISABLE_SETTINGS_METRICS`
   Use the flag if you don't want to scrape `pg_settings`. Value can be `true` or `false`. Default is `false`.
+
+* `PG_EXPORTER_PROBE_TARGET_ALLOWLIST`
+  Optional comma-separated allowlist for `/probe` target values. Entries support `CIDR` and `host:port`. Default is empty (allow all targets).
 
 * `PG_EXPORTER_AUTO_DISCOVER_DATABASES` (DEPRECATED)
   Whether to discover the databases on a server dynamically. Value can be `true` or `false`. Default is `false`.

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -52,6 +52,7 @@ var (
 	includeDatabases       = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled (DEPRECATED)").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
 	metricPrefix           = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
 	collectionTimeout      = kingpin.Flag("collection-timeout", "Timeout for collecting the statistics when the database is slow").Default("1m").Envar("PG_EXPORTER_COLLECTION_TIMEOUT").String()
+	probeTargetAllowlist   = kingpin.Flag("probe-target-allowlist", "Optional comma-separated allowlist for /probe target. Entries support CIDR and host:port. Empty means allow all targets.").Default("").Envar("PG_EXPORTER_PROBE_TARGET_ALLOWLIST").String()
 	logger                 = promslog.NewNopLogger()
 )
 
@@ -95,6 +96,12 @@ func main() {
 
 	if *constantLabelsList != "" {
 		logger.Warn("Constant labels on all metrics is DEPRECATED")
+	}
+
+	targetAllowlist, err := newTargetAllowlist(*probeTargetAllowlist)
+	if err != nil {
+		logger.Error("Invalid /probe target allowlist", "err", err)
+		os.Exit(1)
 	}
 
 	opts := []exporter.ExporterOpt{
@@ -157,7 +164,7 @@ func main() {
 		http.Handle("/", landingPage)
 	}
 
-	http.HandleFunc("/probe", handleProbe(logger, excludedDatabases))
+	http.HandleFunc("/probe", handleProbe(logger, excludedDatabases, targetAllowlist))
 
 	srv := &http.Server{}
 	if err := web.ListenAndServe(srv, webConfig, logger); err != nil {

--- a/cmd/postgres_exporter/probe.go
+++ b/cmd/postgres_exporter/probe.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func handleProbe(logger *slog.Logger, excludeDatabases []string) http.HandlerFunc {
+func handleProbe(logger *slog.Logger, excludeDatabases []string, allowlist *targetAllowlist) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		conf := c.GetConfig()
@@ -58,6 +58,31 @@ func handleProbe(logger *slog.Logger, excludeDatabases []string) http.HandlerFun
 			http.Error(w, fmt.Sprintf("could not configure dsn for target: %v", err), http.StatusBadRequest)
 			return
 		}
+		connectionString := dsn.GetConnectionString()
+		targetHost, targetPort, err := targetEndpointFromDSN(connectionString)
+		if err != nil {
+			logger.Error("failed to parse target endpoint", "err", err)
+			http.Error(w, "target is invalid", http.StatusBadRequest)
+			return
+		}
+		connectHost, allowed := allowlist.resolveConnectionHost(ctx, targetHost, targetPort)
+		if !allowed {
+			logger.Warn("probe target denied by allowlist", "target", target, "host", targetHost, "port", targetPort)
+			http.Error(w, "target is not allowed", http.StatusForbidden)
+			return
+		}
+		connectionString, err = rewriteDSNHost(connectionString, connectHost, targetPort)
+		if err != nil {
+			logger.Error("failed to rewrite target endpoint", "err", err)
+			http.Error(w, "target is invalid", http.StatusBadRequest)
+			return
+		}
+		dsn, err = authModule.ConfigureTarget(connectionString)
+		if err != nil {
+			logger.Error("failed to reconfigure target", "err", err)
+			http.Error(w, "target is invalid", http.StatusBadRequest)
+			return
+		}
 
 		// TODO(@sysadmind): Timeout
 
@@ -76,7 +101,7 @@ func handleProbe(logger *slog.Logger, excludeDatabases []string) http.HandlerFun
 			exporter.WithMetricPrefix(*metricPrefix),
 		}
 
-		dsns := []string{dsn.GetConnectionString()}
+		dsns := []string{connectionString}
 		exporter := exporter.NewExporter(dsns, logger, opts...)
 		defer func() {
 			exporter.CloseServers()

--- a/cmd/postgres_exporter/probe_allowlist.go
+++ b/cmd/postgres_exporter/probe_allowlist.go
@@ -1,0 +1,165 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const defaultPostgresPort = "5432"
+
+type ipResolver func(context.Context, string) ([]net.IP, error)
+
+type targetAllowlist struct {
+	cidrs    []*net.IPNet
+	endpoints map[string]struct{}
+	resolve  ipResolver
+}
+
+func newTargetAllowlist(raw string) (*targetAllowlist, error) {
+	allowlist := &targetAllowlist{
+		endpoints: map[string]struct{}{},
+		resolve: func(ctx context.Context, host string) ([]net.IP, error) {
+			return net.DefaultResolver.LookupIP(ctx, "ip", host)
+		},
+	}
+
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if _, cidr, err := net.ParseCIDR(entry); err == nil {
+			allowlist.cidrs = append(allowlist.cidrs, cidr)
+			continue
+		}
+
+		host, port, err := net.SplitHostPort(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid allowlist entry %q: use CIDR or host:port (for example 10.0.0.0/8 or db.internal:5432)", entry)
+		}
+		if host == "" {
+			return nil, fmt.Errorf("invalid allowlist entry %q: empty host", entry)
+		}
+		if !isValidPort(port) {
+			return nil, fmt.Errorf("invalid allowlist entry %q: invalid port", entry)
+		}
+		allowlist.endpoints[normalizeEndpoint(host, port)] = struct{}{}
+	}
+
+	return allowlist, nil
+}
+
+func (a *targetAllowlist) allows(ctx context.Context, host, port string) bool {
+	_, ok := a.resolveConnectionHost(ctx, host, port)
+	return ok
+}
+
+func (a *targetAllowlist) resolveConnectionHost(ctx context.Context, host, port string) (string, bool) {
+	if a == nil || (len(a.cidrs) == 0 && len(a.endpoints) == 0) {
+		return host, true
+	}
+	if port == "" {
+		port = defaultPostgresPort
+	}
+	if _, ok := a.endpoints[normalizeEndpoint(host, port)]; ok {
+		return host, true
+	}
+	if len(a.cidrs) == 0 {
+		return "", false
+	}
+
+	ips := []net.IP{}
+	if ip := net.ParseIP(host); ip != nil {
+		ips = append(ips, ip)
+	} else {
+		resolved, err := a.resolve(ctx, host)
+		if err != nil {
+			return "", false
+		}
+		ips = resolved
+	}
+
+	for _, ip := range ips {
+		for _, cidr := range a.cidrs {
+			if cidr.Contains(ip) {
+				return ip.String(), true
+			}
+		}
+	}
+	return "", false
+}
+
+func targetEndpointFromDSN(dsn string) (string, string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid DSN: %w", err)
+	}
+	host := strings.TrimSpace(u.Hostname())
+	if host == "" {
+		return "", "", fmt.Errorf("DSN has no host")
+	}
+	port := strings.TrimSpace(u.Port())
+	if port == "" {
+		port = defaultPostgresPort
+	}
+	return host, port, nil
+}
+
+func isValidPort(port string) bool {
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return false
+	}
+	return p > 0 && p <= 65535
+}
+
+func normalizeEndpoint(host, port string) string {
+	return strings.ToLower(strings.TrimSpace(host)) + ":" + strings.TrimSpace(port)
+}
+
+func rewriteDSNHost(connectionString, host, port string) (string, error) {
+	u, err := url.Parse(connectionString)
+	if err != nil {
+		return "", fmt.Errorf("invalid DSN: %w", err)
+	}
+	originalHost := strings.TrimSpace(u.Hostname())
+	if originalHost == "" {
+		return "", fmt.Errorf("DSN has no host")
+	}
+	if strings.TrimSpace(port) == "" {
+		port = strings.TrimSpace(u.Port())
+	}
+
+	query := u.Query()
+	resolvedIsIP := net.ParseIP(host) != nil
+	originalIsIP := net.ParseIP(originalHost) != nil
+
+	if resolvedIsIP && !originalIsIP {
+		// Keep hostname for TLS hostname verification (sslmode=verify-full)
+		// while pinning the actual connection address to the allowlisted IP.
+		query.Set("hostaddr", host)
+		u.Host = net.JoinHostPort(originalHost, port)
+	} else {
+		query.Del("hostaddr")
+		u.Host = net.JoinHostPort(host, port)
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}

--- a/cmd/postgres_exporter/probe_allowlist_test.go
+++ b/cmd/postgres_exporter/probe_allowlist_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"testing"
+)
+
+func TestTargetAllowlist_DefaultAllowsAll(t *testing.T) {
+	t.Parallel()
+
+	allowlist, err := newTargetAllowlist("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowlist.allows(context.Background(), "anything", "5432") {
+		t.Fatal("expected empty allowlist to allow all targets")
+	}
+}
+
+func TestTargetAllowlist_HostPortAndValidation(t *testing.T) {
+	t.Parallel()
+
+	allowlist, err := newTargetAllowlist("db.internal:5432")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowlist.allows(context.Background(), "db.internal", "5432") {
+		t.Fatal("expected host:port rule to match")
+	}
+	if allowlist.allows(context.Background(), "db.internal", "5433") {
+		t.Fatal("expected host:port rule to reject other ports")
+	}
+	if _, err := newTargetAllowlist("db.internal"); err == nil {
+		t.Fatal("expected host without port to be rejected")
+	}
+}
+
+func TestTargetAllowlist_CIDRMatching(t *testing.T) {
+	t.Parallel()
+
+	allowlist := &targetAllowlist{
+		cidrs:    []*net.IPNet{mustCIDR(t, "10.0.0.0/8")},
+		endpoints: map[string]struct{}{},
+		resolve: func(_ context.Context, host string) ([]net.IP, error) {
+			if host == "db.internal" {
+				return []net.IP{net.ParseIP("10.1.2.3")}, nil
+			}
+			return []net.IP{net.ParseIP("192.168.1.1")}, nil
+		},
+	}
+
+	if !allowlist.allows(context.Background(), "db.internal", "5432") {
+		t.Fatal("expected CIDR rule to allow matching IP")
+	}
+	connectHost, ok := allowlist.resolveConnectionHost(context.Background(), "db.internal", "5432")
+	if !ok {
+		t.Fatal("expected CIDR rule to return allowed connection host")
+	}
+	if connectHost != "10.1.2.3" {
+		t.Fatalf("expected resolved IP to be pinned for connection, got %q", connectHost)
+	}
+	if allowlist.allows(context.Background(), "other.internal", "5432") {
+		t.Fatal("expected CIDR rule to reject non-matching IP")
+	}
+}
+
+func TestRewriteDSNHost_HostnameToIPUsesHostaddr(t *testing.T) {
+	t.Parallel()
+
+	out, err := rewriteDSNHost("postgresql://user:pass@db.internal:5432/postgres?sslmode=verify-full", "10.1.2.3", "5432")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(out)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if got := u.Hostname(); got != "db.internal" {
+		t.Fatalf("unexpected host: got %q, want %q", got, "db.internal")
+	}
+	if got := u.Query().Get("sslmode"); got != "verify-full" {
+		t.Fatalf("unexpected sslmode: got %q, want %q", got, "verify-full")
+	}
+	if got := u.Query().Get("hostaddr"); got != "10.1.2.3" {
+		t.Fatalf("unexpected hostaddr: got %q, want %q", got, "10.1.2.3")
+	}
+}
+
+func TestRewriteDSNHost_IPTargetDoesNotSetHostaddr(t *testing.T) {
+	t.Parallel()
+
+	out, err := rewriteDSNHost("postgresql://user:pass@10.1.1.10:5432/postgres?sslmode=disable", "10.1.2.3", "5432")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(out)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if got := u.Hostname(); got != "10.1.2.3" {
+		t.Fatalf("unexpected host: got %q, want %q", got, "10.1.2.3")
+	}
+	if got := u.Query().Get("hostaddr"); got != "" {
+		t.Fatalf("unexpected hostaddr: got %q, want empty", got)
+	}
+}
+
+func mustCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("invalid test CIDR %q: %v", cidr, err)
+	}
+	return ipnet
+}


### PR DESCRIPTION
## Summary

Adds an optional **allowlist** for the multi-target **`/probe`** endpoint so operators can restrict which hosts/IPs and ports the exporter may connect to. This mitigates **SSRF-style abuse** of an open `/probe` URL and hardens checks against **DNS rebinding**. When the allowlist is **non-empty**, resolved addresses must match **CIDR** and/or **host:port** entries. **`sslmode=verify-full`** semantics are preserved when the probe DSN is rewritten.

## Motivation

With `/probe?target=…`, anyone who can reach the exporter can ask it to connect to arbitrary Postgres endpoints. In shared or less trusted networks this is risky. An explicit allowlist is a standard control for this pattern (similar to other multi-target exporters).

## Security context (Prometheus model)

The [Prometheus security model](https://prometheus.io/docs/operating/security/) notes that some exporters accept targets via URL parameters, so anyone who can reach the exporter’s HTTP endpoint may be able to make it connect to **arbitrary** endpoints. The multi-target `/probe?target=…` pattern in postgres_exporter falls into that category.

This change does **not** replace network controls, reverse proxies, authentication, or the general guidance not to expose monitoring HTTP to untrusted networks as the primary defense. It adds an **optional**, configuration-side **restriction on where `/probe` may connect**, for operators who want extra control on top of their deployment model.

## Intended use

The feature is **opt-in** and **off by default**: an empty allowlist keeps existing behavior (all targets allowed). It is aimed mainly at deployments where the exporter is reachable from a **broader or less trusted part of a corporate network** (or similar), and operators still use `/probe` instead of a sidecar—**only when they choose** to constrain which Postgres endpoints may be probed through this instance.

## Behavior

- **Flag:** `--probe-target-allowlist`
- **Environment variable:** `PG_EXPORTER_PROBE_TARGET_ALLOWLIST`
- **Format:** comma-separated **`CIDR`** and/or **`host:port`** (for example `10.0.0.0/8`, `db.example.com:5432`)
- **Default (empty):** unchanged behavior — **all** probe targets allowed (backward compatible)

## Implementation notes

- Allowlist validation uses resolved IPs where relevant to reduce **DNS rebinding** issues.
- Probe DSN rewriting keeps **TLS `verify-full`** behavior consistent with the connection path.

## Documentation and tests

- README updated (usage, flags, env var).
- Unit tests in `probe_allowlist_test.go`.