### PR TITLE
stat_replication: fix "slot_name does not exist" by joining pg_replication_slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / (unreleased)
 
+* [BUGFIX] stat_replication: fix "slot_name does not exist" by joining `pg_replication_slots` (closes #1310)
+
 ## 0.20.0 / 2026-06-29
 
 BREAKING CHANGES:
@@ -43,7 +45,6 @@ its `--no-collector.*` flag.
 * [ENHANCEMENT] Publish container images to GHCR and update PromCI release automation by @roidelapluie in https://github.com/prometheus-community/postgres_exporter/pull/1322
 * [BUGFIX] Fix duplicate `pg_stat_progress_vacuum` metrics for cross-database vacuums by @steinbrueckri in https://github.com/prometheus-community/postgres_exporter/pull/1262
 * [BUGFIX] Fix `pg_settings` collection when `short_desc` is NULL by @jun-gradial in https://github.com/prometheus-community/postgres_exporter/pull/1327
-
 
 ## 0.19.1 / 2026-02-25
 

--- a/collector/pg_stat_replication.go
+++ b/collector/pg_stat_replication.go
@@ -55,15 +55,20 @@ var (
 		prometheus.Labels{},
 	)
 
+	// slot_name is not a column of pg_stat_replication; it lives on
+	// pg_replication_slots and is linked via the standby's WAL sender
+	// PID. LEFT JOIN so clients that do not use a named slot still get
+	// a row with an empty slot_name label.
 	statReplicationQuery = `
 			SELECT
 				application_name,
 				client_addr::text,
 				state,
-				slot_name,
+				s.slot_name,
 				(case pg_is_in_recovery() when 't' then pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_lsn('0/0'))::float else pg_wal_lsn_diff(pg_current_wal_lsn(), pg_lsn('0/0'))::float end) AS pg_current_wal_lsn_bytes,
 				(case pg_is_in_recovery() when 't' then pg_wal_lsn_diff(pg_last_wal_receive_lsn(), replay_lsn)::float else pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn)::float end) AS pg_wal_lsn_diff
 			FROM pg_stat_replication
+			LEFT JOIN pg_replication_slots s ON s.active_pid = pg_stat_replication.pid
 			`
 
 	statReplicationQueryBefore10 = `
@@ -71,7 +76,20 @@ var (
 				application_name,
 				client_addr::text,
 				state,
-				slot_name,
+				s.slot_name,
+				(case pg_is_in_recovery() when 't' then pg_xlog_location_diff(pg_last_xlog_receive_location(), replay_location)::float else pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float end) AS pg_xlog_location_diff
+			FROM pg_stat_replication
+			LEFT JOIN pg_replication_slots s ON s.active_pid = pg_stat_replication.pid
+			`
+
+	// pg_replication_slots.active_pid only exists on PostgreSQL 9.5+, so
+	// on older versions slot_name cannot be resolved; the label is left
+	// empty (matching the legacy yaml exporter behavior).
+	statReplicationQueryBefore95 = `
+			SELECT
+				application_name,
+				client_addr::text,
+				state,
 				(case pg_is_in_recovery() when 't' then pg_xlog_location_diff(pg_last_xlog_receive_location(), replay_location)::float else pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float end) AS pg_xlog_location_diff
 			FROM pg_stat_replication
 			`
@@ -81,8 +99,10 @@ func (PGStatReplicationCollector) Update(ctx context.Context, instance *instance
 	switch {
 	case instance.version.GTE(semver.MustParse("10.0.0")):
 		return updateStatReplication(ctx, instance, ch)
-	case instance.version.GTE(semver.MustParse("9.2.0")):
+	case instance.version.GTE(semver.MustParse("9.5.0")):
 		return updateStatReplicationBefore10(ctx, instance, ch)
+	case instance.version.GTE(semver.MustParse("9.2.0")):
+		return updateStatReplicationBefore95(ctx, instance, ch)
 	default:
 		return nil
 	}
@@ -146,6 +166,34 @@ func updateStatReplicationBefore10(ctx context.Context, instance *instance, ch c
 				prometheus.GaugeValue,
 				xlogLocationDiff.Float64,
 				statReplicationLabelValues(applicationName, clientAddr, state, slotName)...,
+			)
+		}
+	}
+
+	return rows.Err()
+}
+
+func updateStatReplicationBefore95(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+	db := instance.getDB()
+	rows, err := db.QueryContext(ctx, statReplicationQueryBefore95)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var applicationName, clientAddr, state sql.NullString
+		var xlogLocationDiff sql.NullFloat64
+		if err := rows.Scan(&applicationName, &clientAddr, &state, &xlogLocationDiff); err != nil {
+			return err
+		}
+
+		if xlogLocationDiff.Valid {
+			ch <- prometheus.MustNewConstMetric(
+				statReplicationXlogLocationDiffDesc,
+				prometheus.GaugeValue,
+				xlogLocationDiff.Float64,
+				statReplicationLabelValues(applicationName, clientAddr, state, sql.NullString{})...,
 			)
 		}
 	}

--- a/collector/pg_stat_replication_test.go
+++ b/collector/pg_stat_replication_test.go
@@ -123,6 +123,55 @@ func TestPGStatReplicationCollectorBefore10(t *testing.T) {
 	}
 }
 
+func TestPGStatReplicationCollectorBefore95(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening a stub db connection: %s", err)
+	}
+	defer db.Close()
+
+	inst := &instance{db: db, version: semver.MustParse("9.4.0")}
+
+	rows := sqlmock.NewRows([]string{
+		"application_name",
+		"client_addr",
+		"state",
+		"pg_xlog_location_diff",
+	}).AddRow("standby", "10.0.0.1", "streaming", 32.0)
+	mock.ExpectQuery(sanitizeQuery(statReplicationQueryBefore95)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		c := PGStatReplicationCollector{}
+		if err := c.Update(context.Background(), inst, ch); err != nil {
+			t.Errorf("Error calling PGStatReplicationCollector.Update: %s", err)
+		}
+	}()
+
+	expected := []MetricResult{
+		{
+			labels: labelMap{
+				"application_name": "standby",
+				"client_addr":      "10.0.0.1",
+				"state":            "streaming",
+				"slot_name":        "",
+			},
+			value:      32,
+			metricType: dto.MetricType_GAUGE,
+		},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			m := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, m)
+		}
+	})
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}
+
 func TestPGStatReplicationCollectorNullValues(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #1310. The `stat_replication` collector currently fails every scrape with `pq: column "slot_name" does not exist` — affects every user on `main` after #1306, not just Aurora (despite the issue title).

The fix is a `LEFT JOIN pg_replication_slots s ON s.active_pid = pg_stat_replication.pid` so that `slot_name` is read from the view where it actually lives, with an empty label when no named slot is in use.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean.
- [x] Live: vanilla PG 17.10.0 — `pg_scrape_collector_success{collector="stat_replication"} = 1` (was `0`).
- [x] Live: Aurora PG 17.7.0 — `pg_scrape_collector_success{collector="stat_replication"} = 1` (was `0`).

<details>
<summary>Full timeline and root cause</summary>

### Timeline

1. **Before #1306**, `pg_stat_replication` was scraped through the legacy yaml-driven exporter with a `SELECT * FROM pg_stat_replication` query. The yaml mapping listed `slot_name` as a label, but the column does not actually exist on `pg_stat_replication` — so the yaml exporter silently produced an empty label. No error.

2. **`slot_name` has never been a column of `pg_stat_replication`** on any supported PG version. It lives on `pg_replication_slots`. To populate it for an active WAL sender you have to JOIN the two views. The legacy yaml never did. The label was effectively aspirational — described, but always empty. A latent bug sat in `queries.yaml` for years.

3. **#1306 ("Refactor stat_replication into standalone collector")** migrated this query into a Go-native collector. The new SQL was rewritten with an explicit column list, including `slot_name`:

   ```sql
   SELECT application_name, client_addr::text, state, slot_name, ...
   FROM pg_stat_replication
   ```

   That promoted `slot_name` from "yaml label silently missing" to "explicit SQL column that must exist". It does not.

4. **CI on #1306 went green** because unit tests for `stat_replication` use `sqlmock`, which returns whatever columns the test declares — the real Postgres schema is never validated. Integration tests apparently do not exercise this collector. The bug shipped.

5. **After #1306 merged**, `stat_replication` fails on every scrape, on every PG version. Because it is `defaultEnabled`, every user is affected automatically.

### Verification that `slot_name` is not on `pg_stat_replication`

Three independent sources:

1. `\d pg_stat_replication` on `postgres:17.10.0` Docker — 20 columns, no `slot_name`.
2. `\d pg_stat_replication` on `postgres:18` Docker — 20 columns, no `slot_name`.
3. Official docs for [PG 17](https://www.postgresql.org/docs/17/monitoring-stats.html#MONITORING-PG-STAT-REPLICATION-VIEW) and [PG 18](https://www.postgresql.org/docs/18/monitoring-stats.html#MONITORING-PG-STAT-REPLICATION-VIEW) — 20 columns documented, no `slot_name`. The PG 18 docs explicitly note `slot_name` lives on `pg_stat_replication_slots`.

### Fix details

`LEFT JOIN pg_replication_slots s ON s.active_pid = pg_stat_replication.pid` and read `s.slot_name`. Behavior:

* Replication client using a named slot → `slot_name` populated.
* Replication client without a slot → `slot_name` empty (matches legacy yaml behavior).
* Aurora and other setups without physical replication slots → `slot_name` empty.

Applied to both the PG ≥ 10 and pre-10 query paths. `pg_replication_slots` exists since PG 9.4, so the pre-9.4 branch remains affected by the same root cause; that branch is not in CI scope and was already broken before this PR.

</details>
