### PR TITLE
Fix short_desc null bug with coalesce wrapping

### DIFF
--- a/collector/pg_setting.go
+++ b/collector/pg_setting.go
@@ -52,7 +52,7 @@ var (
 	// Settings intentionally ignored due to invalid format:
 	// - `sync_commit_cancel_wait`, specific to Azure Postgres, see https://github.com/prometheus-community/postgres_exporter/issues/523
 	// - `google_dataplex.max_messages`, specific to Google Cloud SQL, see https://github.com/prometheus-community/postgres_exporter/issues/1240
-	pgSettingsQuery = "SELECT name, setting, COALESCE(unit, ''), short_desc, vartype FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real') AND name NOT IN ('sync_commit_cancel_wait', 'google_dataplex.max_messages');"
+	pgSettingsQuery = "SELECT name, setting, COALESCE(unit, ''), COALESCE(short_desc, ''), vartype FROM pg_settings WHERE vartype IN ('bool', 'integer', 'real') AND name NOT IN ('sync_commit_cancel_wait', 'google_dataplex.max_messages');"
 )
 
 // Update implements Collector and exposes PostgreSQL runtime settings.


### PR DESCRIPTION
Summary:
- Fixes https://github.com/prometheus-community/postgres_exporter/issues/1186.
- `pg_settings.short_desc` can be `NULL` on some PostgreSQL-compatible systems, which causes the collector scan to fail with `converting NULL to string is unsupported` because the value is scanned into a Go string.
- Match the existing nullable `unit` handling by wrapping `short_desc` with `COALESCE(short_desc, '')`, so settings collection can continue when this optional description is missing.

Tests:
- `gofmt -w collector/pg_setting.go collector/pg_setting_test.go`
- `go test ./collector`
