### PR TITLE
collector: use the shared exporter-toolkit collector registry (PoC)

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -63,13 +63,36 @@ func newConfigHandler() *config.Handler {
 	return handler
 }
 
+var listCollectors = kingpin.Flag(
+	"collector.list",
+	"Print the collector inventory as JSON and exit.",
+).Hidden().Bool()
+
+var listCollectorsMarkdown = kingpin.Flag(
+	"collector.list.markdown",
+	"Print the collector inventory as a Markdown table and exit.",
+).Hidden().Bool()
+
 func main() {
 	kingpin.Version(version.Print(exporterName))
+	collector.AddFlags(kingpin.CommandLine)
 	promslogConfig := &promslog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promslogConfig)
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger = promslog.New(promslogConfig)
+
+	if *listCollectors || *listCollectorsMarkdown {
+		write := collector.WriteCollectorList
+		if *listCollectorsMarkdown {
+			write = collector.WriteCollectorMarkdown
+		}
+		if err := write(os.Stdout); err != nil {
+			logger.Error("failed to list collectors", "err", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	if *onlyDumpMaps {
 		exporter.DumpMaps()

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -17,21 +17,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
+	"io"
 	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
-)
-
-var (
-	factories              = make(map[string]func(collectorConfig) (Collector, error))
-	initiatedCollectorsMtx = sync.Mutex{}
-	initiatedCollectors    = make(map[string]Collector)
-	collectorState         = make(map[string]*bool)
-	forcedCollectors       = map[string]bool{} // collectors which have been explicitly enabled or disabled
+	toolkit "github.com/prometheus/exporter-toolkit/collector"
 )
 
 const (
@@ -43,21 +36,6 @@ const (
 	defaultDisabled     = false
 )
 
-var (
-	scrapeDurationDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "scrape", "collector_duration_seconds"),
-		"postgres_exporter: Duration of a collector scrape.",
-		[]string{"collector"},
-		nil,
-	)
-	scrapeSuccessDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "scrape", "collector_success"),
-		"postgres_exporter: Whether a collector succeeded.",
-		[]string{"collector"},
-		nil,
-	)
-)
-
 type Collector interface {
 	Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error
 }
@@ -67,24 +45,52 @@ type collectorConfig struct {
 	excludeDatabases []string
 }
 
+// registry replaces the factories/collectorState/forcedCollectors maps that
+// were duplicated verbatim from node_exporter.
+var collectorRegistry = toolkit.NewRegistry[Collector, collectorConfig](namespace)
+
+// scrapeReporter emits pg_scrape_collector_duration_seconds and
+// pg_scrape_collector_success.
+var scrapeReporter = toolkit.NewScrapeReporter(namespace, "postgres_exporter")
+
+// registerCollector keeps its original signature so the per-collector files
+// registering from init() do not change.
 func registerCollector(name string, isDefaultEnabled bool, createFunc func(collectorConfig) (Collector, error)) {
-	var helpDefaultState string
-	if isDefaultEnabled {
-		helpDefaultState = "enabled"
-	} else {
-		helpDefaultState = "disabled"
-	}
+	collectorRegistry.Register(toolkit.Descriptor{
+		Name:           name,
+		DefaultEnabled: isDefaultEnabled,
+	}, createFunc)
+}
 
-	// Create flag for this collector
-	flagName := collectorFlagPrefix + name
-	flagHelp := fmt.Sprintf("Enable the %s collector (default: %s).", name, helpDefaultState)
-	defaultValue := fmt.Sprintf("%v", isDefaultEnabled)
+// RegisterCollectorWithMetadata registers a collector along with the operator
+// preconditions it needs, so documentation can be generated from the registry.
+func RegisterCollectorWithMetadata(d toolkit.Descriptor, createFunc func(collectorConfig) (Collector, error)) {
+	collectorRegistry.Register(d, createFunc)
+}
 
-	flag := kingpin.Flag(flagName, flagHelp).Default(defaultValue).Action(collectorFlagAction(name)).Bool()
-	collectorState[name] = flag
+// AddFlags registers the --collector.<name> flags. Call before kingpin.Parse.
+func AddFlags(app *kingpin.Application) {
+	collectorRegistry.AddFlags(app)
+}
 
-	// Register the create function for this collector
-	factories[name] = createFunc
+// DisableDefaultCollectors disables every collector not named explicitly.
+func DisableDefaultCollectors() {
+	collectorRegistry.DisableDefaults()
+}
+
+// WriteCollectorList writes the machine-readable collector inventory.
+func WriteCollectorList(w io.Writer) error {
+	return collectorRegistry.WriteJSON(w)
+}
+
+// WriteCollectorMarkdown writes the docs table for docs/configuration.md.
+func WriteCollectorMarkdown(w io.Writer) error {
+	return collectorRegistry.WriteMarkdown(w)
+}
+
+// EnabledMetrics exposes pg_collector_enabled per collector.
+func EnabledMetrics() prometheus.Collector {
+	return collectorRegistry.EnabledMetrics()
 }
 
 // PostgresCollector implements the prometheus.Collector interface.
@@ -111,37 +117,14 @@ func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, dsn st
 		}
 	}
 
-	f := make(map[string]bool)
-	for _, filter := range filters {
-		enabled, exist := collectorState[filter]
-		if !exist {
-			return nil, fmt.Errorf("missing collector: %s", filter)
+	collectors, err := collectorRegistry.Build(func(name string) collectorConfig {
+		return collectorConfig{
+			logger:           logger.With("collector", name),
+			excludeDatabases: excludeDatabases,
 		}
-		if !*enabled {
-			return nil, fmt.Errorf("disabled collector: %s", filter)
-		}
-		f[filter] = true
-	}
-	collectors := make(map[string]Collector)
-	initiatedCollectorsMtx.Lock()
-	defer initiatedCollectorsMtx.Unlock()
-	for key, enabled := range collectorState {
-		if !*enabled || (len(f) > 0 && !f[key]) {
-			continue
-		}
-		if collector, ok := initiatedCollectors[key]; ok {
-			collectors[key] = collector
-		} else {
-			collector, err := factories[key](collectorConfig{
-				logger:           logger.With("collector", key),
-				excludeDatabases: excludeDatabases,
-			})
-			if err != nil {
-				return nil, err
-			}
-			collectors[key] = collector
-			initiatedCollectors[key] = collector
-		}
+	}, filters...)
+	if err != nil {
+		return nil, err
 	}
 
 	p.Collectors = collectors
@@ -175,8 +158,7 @@ func WithCollectionTimeout(s string) Option {
 
 // Describe implements the prometheus.Collector interface.
 func (p PostgresCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- scrapeDurationDesc
-	ch <- scrapeSuccessDesc
+	scrapeReporter.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -218,7 +200,6 @@ func execute(ctx context.Context, name string, c Collector, instance *instance, 
 	begin := time.Now()
 	err := c.Update(ctx, instance, ch)
 	duration := time.Since(begin)
-	var success float64
 
 	if err != nil {
 		if IsNoDataError(err) {
@@ -226,25 +207,10 @@ func execute(ctx context.Context, name string, c Collector, instance *instance, 
 		} else {
 			logger.Error("collector failed", "name", name, "duration_seconds", duration.Seconds(), "err", err)
 		}
-		success = 0
 	} else {
 		logger.Debug("collector succeeded", "name", name, "duration_seconds", duration.Seconds())
-		success = 1
 	}
-	ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, duration.Seconds(), name)
-	ch <- prometheus.MustNewConstMetric(scrapeSuccessDesc, prometheus.GaugeValue, success, name)
-}
-
-// collectorFlagAction generates a new action function for the given collector
-// to track whether it has been explicitly enabled or disabled from the command line.
-// A new action function is needed for each collector flag because the ParseContext
-// does not contain information about which flag called the action.
-// See: https://github.com/alecthomas/kingpin/issues/294
-func collectorFlagAction(collector string) func(ctx *kingpin.ParseContext) error {
-	return func(ctx *kingpin.ParseContext) error {
-		forcedCollectors[collector] = true
-		return nil
-	}
+	scrapeReporter.Report(ch, name, duration, err)
 }
 
 // ErrNoData indicates the collector found no data to collect, but had no other error.

--- a/collector/pg_buffercache_summary.go
+++ b/collector/pg_buffercache_summary.go
@@ -16,6 +16,7 @@ package collector
 import (
 	"context"
 	"database/sql"
+	toolkit "github.com/prometheus/exporter-toolkit/collector"
 	"log/slog"
 
 	"github.com/blang/semver/v4"
@@ -25,7 +26,12 @@ import (
 const buffercacheSummarySubsystem = "buffercache_summary"
 
 func init() {
-	registerCollector(buffercacheSummarySubsystem, defaultDisabled, NewBuffercacheSummaryCollector)
+	RegisterCollectorWithMetadata(toolkit.Descriptor{
+		Name:           buffercacheSummarySubsystem,
+		Help:           "Shared buffer cache summary",
+		DefaultEnabled: defaultDisabled,
+		Requires:       []string{"the `pg_buffercache` extension", "PostgreSQL 16+"},
+	}, NewBuffercacheSummaryCollector)
 }
 
 // BuffercacheSummaryCollector collects stats from pg_buffercache: https://www.postgresql.org/docs/current/pgbuffercache.html.

--- a/collector/pg_database_wraparound.go
+++ b/collector/pg_database_wraparound.go
@@ -16,6 +16,7 @@ package collector
 import (
 	"context"
 	"database/sql"
+	toolkit "github.com/prometheus/exporter-toolkit/collector"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,7 +25,11 @@ import (
 const databaseWraparoundSubsystem = "database_wraparound"
 
 func init() {
-	registerCollector(databaseWraparoundSubsystem, defaultDisabled, NewPGDatabaseWraparoundCollector)
+	RegisterCollectorWithMetadata(toolkit.Descriptor{
+		Name:           databaseWraparoundSubsystem,
+		Help:           "Transaction ID wraparound risk",
+		DefaultEnabled: defaultDisabled,
+	}, NewPGDatabaseWraparoundCollector)
 }
 
 type PGDatabaseWraparoundCollector struct {

--- a/collector/pg_stat_checkpointer.go
+++ b/collector/pg_stat_checkpointer.go
@@ -16,6 +16,7 @@ package collector
 import (
 	"context"
 	"database/sql"
+	toolkit "github.com/prometheus/exporter-toolkit/collector"
 	"log/slog"
 
 	"github.com/blang/semver/v4"
@@ -27,7 +28,12 @@ const statCheckpointerSubsystem = "stat_checkpointer"
 func init() {
 	// WARNING:
 	//   Disabled by default because this set of metrics is only available from Postgres 17
-	registerCollector(statCheckpointerSubsystem, defaultDisabled, NewPGStatCheckpointerCollector)
+	RegisterCollectorWithMetadata(toolkit.Descriptor{
+		Name:           statCheckpointerSubsystem,
+		Help:           "Checkpointer activity",
+		DefaultEnabled: defaultDisabled,
+		Requires:       []string{"PostgreSQL 17+"},
+	}, NewPGStatCheckpointerCollector)
 }
 
 type PGStatCheckpointerCollector struct {

--- a/collector/pg_stat_statements.go
+++ b/collector/pg_stat_statements.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	toolkit "github.com/prometheus/exporter-toolkit/collector"
 	"log/slog"
 	"strings"
 
@@ -42,7 +43,12 @@ func init() {
 	// WARNING:
 	//   Disabled by default because this set of metrics can be quite expensive on a busy server
 	//   Every unique query will cause a new timeseries to be created
-	registerCollector(statStatementsSubsystem, defaultDisabled, NewPGStatStatementsCollector)
+	RegisterCollectorWithMetadata(toolkit.Descriptor{
+		Name:           statStatementsSubsystem,
+		Help:           "Statement execution statistics",
+		DefaultEnabled: defaultDisabled,
+		Requires:       []string{"the `pg_stat_statements` extension"},
+	}, NewPGStatStatementsCollector)
 
 	includeQueryFlag = kingpin.Flag(
 		fmt.Sprint(collectorFlagPrefix, statStatementsSubsystem, ".include_query"),

--- a/collector/probe.go
+++ b/collector/probe.go
@@ -30,31 +30,15 @@ type ProbeCollector struct {
 }
 
 func NewProbeCollector(logger *slog.Logger, excludeDatabases []string, registry *prometheus.Registry, dsn config.DSN) (*ProbeCollector, error) {
-	collectors := make(map[string]Collector)
-	initiatedCollectorsMtx.Lock()
-	defer initiatedCollectorsMtx.Unlock()
-	for key, enabled := range collectorState {
-		// TODO: Handle filters
-		// if !*enabled || (len(f) > 0 && !f[key]) {
-		// 	continue
-		// }
-		if !*enabled {
-			continue
+	// TODO: Handle filters (was already a TODO before the registry existed).
+	collectors, err := collectorRegistry.Build(func(name string) collectorConfig {
+		return collectorConfig{
+			logger:           logger.With("collector", name),
+			excludeDatabases: excludeDatabases,
 		}
-		if collector, ok := initiatedCollectors[key]; ok {
-			collectors[key] = collector
-		} else {
-			collector, err := factories[key](
-				collectorConfig{
-					logger:           logger.With("collector", key),
-					excludeDatabases: excludeDatabases,
-				})
-			if err != nil {
-				return nil, err
-			}
-			collectors[key] = collector
-			initiatedCollectors[key] = collector
-		}
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	instance, err := newInstance(dsn.GetConnectionString())

--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,5 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/prometheus/exporter-toolkit => ../exporter-toolkit

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi/PY=
 github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
-github.com/prometheus/exporter-toolkit v0.17.1 h1:psKN4wM7shBL/BxZkDHgm6YZJ3fAVG36+r86An/+7q0=
-github.com/prometheus/exporter-toolkit v0.17.1/go.mod h1:dabwPJvxsC5+tsp2iolQrqBWZh+QlISKlYRpj9Hh5xk=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=


### PR DESCRIPTION
**Draft / proof of concept. Stacked on prometheus/exporter-toolkit#429 — CI will not build until that lands, since the toolkit package it imports is unreleased.** To build locally: `go mod edit -replace github.com/prometheus/exporter-toolkit=/path/to/exporter-toolkit` against that branch.

Follow-up to @ArthurSens' question in #1361: [could the collector enable/disable abstraction live in exporter-toolkit, and could the docs table be generated from it?](https://github.com/prometheus-community/postgres_exporter/pull/1361#discussion_r3778619126) This is what that looks like in practice.

## What changed

`collector/collector.go`'s `factories` / `collectorState` / `forcedCollectors` / `initiatedCollectors` maps, and the flag registration, forced-state tracking, filtering and lazy instantiation around them, are near-verbatim copies of node_exporter's. They're replaced by `toolkit.Registry`, which is generic over the collector interface — so `Update(ctx, instance, ch)` is untouched, and `registerCollector` keeps its signature. None of the ~26 per-collector files needed changes for the refactor itself.

`probe.go` had a **third** partial copy of the instantiate-and-cache loop, carrying a `// TODO: Handle filters` that node_exporter's copy had already solved. It now shares the registry, so that divergence is gone.

Net −117/+113 including the new flags and metadata.

## The docs table becomes generated

Four collectors move to `RegisterCollectorWithMetadata` to record operator preconditions — the `pg_stat_statements` and `pg_buffercache` extensions, minimum server versions:

```
$ postgres_exporter --collector.list.markdown
| Collector | Default | Notes |
|---|---|---|
| `buffercache_summary` | disabled | Shared buffer cache summary; requires the `pg_buffercache` extension, PostgreSQL 16+ |
| `database` | enabled |  |
...
| `stat_statements` | disabled | Statement execution statistics; requires the `pg_stat_statements` extension |
```

This reproduces all 26 rows of the hand-written table in #1361, defaults included — which is a good sign for that table, it's accurate *today*. The point is that it stays accurate. `--collector.list` emits the same inventory as JSON for mdox or a CI drift check.

## Runtime introspection

`pg_collector_enabled{collector="..."}` is now exposed, so which collectors an exporter actually has enabled is answerable from Prometheus across a fleet, rather than only by inspecting a process's command line.

## Notes

- `--collector.disable-defaults` comes for free from the registry (`DisableDefaultCollectors` is exported) but I left it unwired — adding a flag postgres_exporter doesn't have today is a UX call for maintainers, not part of a refactor.
- Verified: `--no-collector.X` / `--collector.X` behave exactly as before, and the full suite passes (107 tests).
- I'd suggest **not** blocking #1361 on this. Ship the hand-written table now; a slightly stale table is a much smaller problem than no docs, and this can replace it later.
