### PR TITLE
main: start the exporter through the toolkit bootstrap package

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `web.telemetry-path`
   Path under which to expose metrics. Default is `/metrics`.
 
+* `web.max-requests`
+  Maximum number of parallel scrape requests. Use `0` to disable. Default is `40`.
+
+* `web.disable-exporter-metrics`
+  Exclude metrics about the exporter itself (`promhttp_*`, `process_*`, `go_*`). Default is `false`.
+
 * `disable-default-metrics`
   Use only metrics supplied from `queries.yaml` via `--extend.query-path`.  Default is `false`.
 
@@ -288,8 +294,8 @@ The following environment variables configure the exporter:
   and will avoid exhausting the pool of connections of the database.
   Value of `0` or less than `1ms` is considered invalid and will report an error.
 
-* `PG_EXPORTER_WEB_TELEMETRY_PATH`
-  Path under which to expose metrics. Default is `/metrics`.
+* `PG_EXPORTER_WEB_TELEMETRY_PATH` (DEPRECATED)
+  Path under which to additionally expose metrics, alongside whatever `--web.telemetry-path` resolves to (both are served; this no longer relocates or overrides the flag). Use `--web.telemetry-path` instead.
 
 * `PG_EXPORTER_DISABLE_DEFAULT_METRICS`
   Use only metrics supplied from `queries.yaml`. Value can be `true` or `false`. Default is `false`.

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -32,16 +33,12 @@ import (
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promslog"
-	"github.com/prometheus/common/promslog/flag"
-	"github.com/prometheus/common/version"
+	"github.com/prometheus/exporter-toolkit/bootstrap"
 	"github.com/prometheus/exporter-toolkit/web"
-	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
 )
 
 var (
 	configFile            = kingpin.Flag("config.file", "Postgres exporter configuration file.").Default("postgres_exporter.yml").String()
-	webConfig             = kingpinflag.AddFlags(kingpin.CommandLine, ":9187")
-	metricsPath           = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").Envar("PG_EXPORTER_WEB_TELEMETRY_PATH").String()
 	disableDefaultMetrics = kingpin.Flag("disable-default-metrics", "Do not include default metrics.").Default("false").Envar("PG_EXPORTER_DISABLE_DEFAULT_METRICS").Bool()
 	autoDiscoverDatabases = kingpin.Flag("auto-discover-databases", "Whether to discover the databases on a server dynamically. (DEPRECATED)").Default("false").Envar("PG_EXPORTER_AUTO_DISCOVER_DATABASES").Bool()
 	queriesPath           = kingpin.Flag("extend.query-path", "Path to custom queries to run. (DEPRECATED)").Default("").Envar("PG_EXPORTER_EXTEND_QUERY_PATH").String()
@@ -61,10 +58,21 @@ var (
 
 	statStatementsFlags = newPGStatStatementsFlags()
 	logger              = promslog.NewNopLogger()
+	// loggerConfigured is false until logger is no longer a no-op (e.g. a flag-parse failure).
+	loggerConfigured = false
 )
 
 // The name of the exporter.
 const exporterName = "postgres_exporter"
+
+// webTelemetryPathEnvar is the legacy metrics-path env var. bootstrap
+// dropped env-var support for --web.telemetry-path (exporter-toolkit#430),
+// so when set, metrics are additionally served at this path alongside the
+// flag, rather than relocated or overridden as before.
+const webTelemetryPathEnvar = "PG_EXPORTER_WEB_TELEMETRY_PATH"
+
+// errDumpMaps signals --dumpmaps so main, not the bootstrap callback, exits.
+var errDumpMaps = errors.New("dumpmaps requested")
 
 type collectorFlagSet map[string]*bool
 
@@ -124,23 +132,54 @@ func newPGStatStatementsFlags() pgStatStatementsFlags {
 }
 
 func main() {
-	kingpin.Version(version.Print(exporterName))
-	promslogConfig := &promslog.Config{}
-	flag.AddFlags(kingpin.CommandLine, promslogConfig)
-	kingpin.HelpFlag.Short('h')
-	kingpin.Parse()
-	logger = promslog.New(promslogConfig)
+	runner := bootstrap.New(bootstrap.Config{
+		App:            kingpin.CommandLine,
+		Name:           exporterName,
+		Description:    "Prometheus PostgreSQL server Exporter",
+		DefaultAddress: ":9187",
+		LandingConfig: web.LandingConfig{
+			Name: "Postgres Exporter",
+		},
+		MetricsHandlerFactory: newMetricsHandler,
+	})
 
-	if *onlyDumpMaps {
+	err := runner.Run()
+	if pgRuntime != nil {
+		if closeErr := pgRuntime.Close(); closeErr != nil {
+			logger.Error("Failed to close runtime", "err", closeErr)
+		}
+	}
+	if errors.Is(err, errDumpMaps) {
 		exporter.DumpMaps()
 		return
+	}
+	if err != nil {
+		if loggerConfigured {
+			logger.Error("Error running exporter", "err", err)
+		} else {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(1)
+	}
+}
+
+// pgRuntime is package level so it can be closed once the server stops.
+var pgRuntime *collector.Runtime
+
+// newMetricsHandler wires up the exporter and registers postgres_exporter's
+// endpoints once the toolkit has parsed flags.
+func newMetricsHandler(b *bootstrap.Bootstrap) (http.Handler, error) {
+	logger = b.Logger
+	loggerConfigured = true
+
+	if *onlyDumpMaps {
+		return nil, errDumpMaps
 	}
 
 	registry := prometheus.NewRegistry()
 	authHandler, err := config.NewHandler(registry)
 	if err != nil {
-		logger.Error("Failed to create config handler", "err", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create config handler: %w", err)
 	}
 
 	if err := authHandler.ReloadAuthConfig(*configFile, logger); err != nil {
@@ -150,14 +189,12 @@ func main() {
 
 	dsns, err := exporter.GetDataSources()
 	if err != nil {
-		logger.Error("Failed reading data sources", "err", err.Error())
-		os.Exit(1)
+		return nil, fmt.Errorf("failed reading data sources: %w", err)
 	}
 
 	cfg, err := buildConfig(dsns)
 	if err != nil {
-		logger.Error("Failed building config", "err", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed building config: %w", err)
 	}
 	logger.Info("Excluded databases", "databases", fmt.Sprintf("%v", cfg.ExcludeDatabases))
 
@@ -175,59 +212,41 @@ func main() {
 
 	validatedConfig, err := cfg.Validate()
 	if err != nil {
-		logger.Error("Invalid config", "err", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	pgRuntime, err := collector.NewRuntime(validatedConfig, logger)
+	runtime, err := collector.NewRuntime(validatedConfig, logger)
 	if err != nil {
-		logger.Error("Failed to create runtime", "err", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create runtime: %w", err)
 	}
-	defer func() {
-		if err := pgRuntime.Close(); err != nil {
-			logger.Error("Failed to close runtime", "err", err)
-		}
-	}()
+	pgRuntime = runtime
 
-	registry.MustRegister(
-		prometheuscollectors.NewGoCollector(),
-		prometheuscollectors.NewProcessCollector(prometheuscollectors.ProcessCollectorOpts{}),
-		versioncollector.NewCollector(exporterName),
-	)
-	for _, collector := range pgRuntime.Collectors() {
+	if !b.DisableExporterMetrics {
+		registry.MustRegister(
+			prometheuscollectors.NewGoCollector(),
+			prometheuscollectors.NewProcessCollector(prometheuscollectors.ProcessCollectorOpts{}),
+		)
+	}
+	registry.MustRegister(versioncollector.NewCollector(exporterName))
+	for _, collector := range runtime.Collectors() {
 		registry.MustRegister(collector)
 	}
 
-	http.Handle(*metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	b.HandleFunc("/probe", handleProbe(logger, authHandler, cfg))
+	// net/http/pprof and the transitively-imported "expvar" package both
+	// register handlers under /debug/ on the default mux.
+	b.Handle("/debug/", http.DefaultServeMux)
 
-	if *metricsPath != "/" && *metricsPath != "" {
-		landingConfig := web.LandingConfig{
-			Name:        "Postgres Exporter",
-			Description: "Prometheus PostgreSQL server Exporter",
-			Version:     version.Info(),
-			Links: []web.LandingLinks{
-				{
-					Address: *metricsPath,
-					Text:    "Metrics",
-				},
-			},
-		}
-		landingPage, err := web.NewLandingPage(landingConfig)
-		if err != nil {
-			logger.Error("error creating landing page", "err", err)
-			os.Exit(1)
-		}
-		http.Handle("/", landingPage)
+	metricsHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+		MaxRequestsInFlight: b.MaxRequests,
+	})
+
+	if legacyPath := os.Getenv(webTelemetryPathEnvar); legacyPath != "" && legacyPath != b.MetricsPath {
+		logger.Warn(webTelemetryPathEnvar+" is DEPRECATED, use --web.telemetry-path instead", "path", legacyPath)
+		b.Handle(legacyPath, metricsHandler)
 	}
 
-	http.HandleFunc("/probe", handleProbe(logger, authHandler, cfg))
-
-	srv := &http.Server{}
-	if err := web.ListenAndServe(srv, webConfig, logger); err != nil {
-		logger.Error("Error running HTTP server", "err", err)
-		os.Exit(1)
-	}
+	return metricsHandler, nil
 }
 
 func buildConfig(dsns []string) (config.Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1
-	github.com/prometheus/exporter-toolkit v0.17.1
+	github.com/prometheus/exporter-toolkit v0.19.0
 	github.com/smartystreets/goconvey v1.8.1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi/PY=
 github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
-github.com/prometheus/exporter-toolkit v0.17.1 h1:psKN4wM7shBL/BxZkDHgm6YZJ3fAVG36+r86An/+7q0=
-github.com/prometheus/exporter-toolkit v0.17.1/go.mod h1:dabwPJvxsC5+tsp2iolQrqBWZh+QlISKlYRpj9Hh5xk=
+github.com/prometheus/exporter-toolkit v0.19.0 h1:JljWCzE5naAiZ7Ukeb8PwjNbU+WwISuW0ktgdXMnMhc=
+github.com/prometheus/exporter-toolkit v0.19.0/go.mod h1:kOoEK/7wbe2Ns33l7wYHOXDZAZ/XGLyJqoGwmJxK+QU=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=


### PR DESCRIPTION
## Summary

Starts `postgres_exporter` on the shared exporter startup path by replacing the hand-rolled `main()` block with `exporter-toolkit/bootstrap`, mirroring prometheus/node_exporter#3660.

The entrypoint currently reimplements what `bootstrap` provides: the `--web.telemetry-path` flag, `kingpinflag`/promslog wiring, version output, landing page construction, and the `web.ListenAndServe` call. Keeping a private copy is how exporters drift apart in flags and startup behavior.

Two notes for review:

- `--dumpmaps` exits from inside the handler factory, since it is an early-exit path and `bootstrap` has no pre-serve hook
- `CloseServers()` now runs after `Run()` returns instead of via `defer`; the old `defer` never actually ran, because every exit path went through `os.Exit`

