### PR TITLE
Allow running without a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ scrape_configs:
 
 ## Configuration File
 
-The configuration file controls the behavior of the exporter. It can be set using the `--config.file` command line flag and defaults to `postgres_exporter.yml`.
+The configuration file controls the behavior of the exporter. It can be set using the `--config.file` command line flag and defaults to `postgres_exporter.yml`. Set `--config.file=""` to run without a configuration file.
 
 ### auth_modules
 This section defines preset authentication and connection parameters for use in the [multi-target endpoint](#multi-target-support-beta). `auth_modules` is a map of modules with the key being the identifier which can be used in the `/probe` endpoint.

--- a/config/config.go
+++ b/config/config.go
@@ -285,6 +285,10 @@ func (ch *Handler) observeReload(err error) {
 }
 
 func LoadAuthConfig(f string) (*AuthConfig, error) {
+	if f == "" {
+		return &AuthConfig{}, nil
+	}
+
 	yamlReader, err := os.Open(f)
 	if err != nil {
 		return nil, fmt.Errorf("error opening config file %q: %s", f, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -212,6 +212,19 @@ func TestLoadAuthConfigFile(t *testing.T) {
 	}
 }
 
+func TestLoadAuthConfigEmptyPath(t *testing.T) {
+	config, err := LoadAuthConfig("")
+	if err != nil {
+		t.Fatalf("LoadAuthConfig() error = %v", err)
+	}
+	if config == nil {
+		t.Fatal("LoadAuthConfig() config = nil, want empty config")
+	}
+	if len(config.AuthModules) != 0 {
+		t.Fatalf("LoadAuthConfig() loaded %d auth modules, want 0", len(config.AuthModules))
+	}
+}
+
 func TestDecodeAuthConfig(t *testing.T) {
 	config, err := DecodeAuthConfig(strings.NewReader(`
 auth_modules:


### PR DESCRIPTION
## Summary
- treat an empty `--config.file` path as an explicit request to run without auth modules
- add regression coverage for loading an empty config path
- document how to disable config-file loading

Supersedes #1263 and carries forward the behavior proposed by @litetex.

Fixes #794.

## Test plan
- [x] `go test ./config -count=1`
- [x] `go test ./...`

Made with [Cursor](https://cursor.com)