### PR TITLE
Add --datasource.* CLI flags as alternatives to DATA_SOURCE_* env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,28 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 * `config.file`
   Set the config file path. Default is `postgres_exporter.yml`
 
+* `datasource.dsn`
+  Postgres connection DSN(s), comma-separated for multiple servers. Takes precedence
+  over all other `datasource.*` flags. Replaces `DATA_SOURCE_NAME`.
+
+* `datasource.uri`
+  Postgres connection host and parameters. Replaces `DATA_SOURCE_URI`.
+
+* `datasource.uri-file`
+  Path to a file containing the value for `datasource.uri`. Replaces `DATA_SOURCE_URI_FILE`.
+
+* `datasource.user`
+  Postgres connection username, used together with `datasource.uri`. Replaces `DATA_SOURCE_USER`.
+
+* `datasource.user-file`
+  Path to a file containing the value for `datasource.user`. Replaces `DATA_SOURCE_USER_FILE`.
+
+* `datasource.pass`
+  Postgres connection password, used together with `datasource.uri`. Replaces `DATA_SOURCE_PASS`.
+
+* `datasource.pass-file`
+  Path to a file containing the value for `datasource.pass`. Replaces `DATA_SOURCE_PASS_FILE`.
+
 * `web.systemd-socket`
   Use systemd socket activation listeners instead of port listeners (Linux only). Default is `false`
 
@@ -249,7 +271,8 @@ This will build the docker image as `prometheuscommunity/postgres_exporter:${bra
 
 ### Environment Variables
 
-The following environment variables configure the exporter:
+The following environment variables configure the exporter. Each has an equivalent
+`--datasource.*` flag (see [Flags](#flags)); the flag takes precedence when both are set.
 
 * `DATA_SOURCE_NAME`
   the default legacy format. Accepts URI form and key=value form arguments. The

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -51,6 +51,13 @@ var (
 	includeDatabases      = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled (DEPRECATED)").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
 	metricPrefix          = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
 	collectionTimeout     = kingpin.Flag("collection-timeout", "Timeout for collecting the statistics when the database is slow").Default("1m").Envar("PG_EXPORTER_COLLECTION_TIMEOUT").String()
+	dataSourceDSN         = kingpin.Flag("datasource.dsn", "Postgres connection DSN(s). Takes precedence over all other datasource.* flags. (replaces DATA_SOURCE_NAME)").Default("").String()
+	dataSourceURI         = kingpin.Flag("datasource.uri", "Postgres connection host and parameters (replaces DATA_SOURCE_URI)").Default("").String()
+	dataSourceURIFile     = kingpin.Flag("datasource.uri-file", "Path to a file containing the postgres connection host and parameters (replaces DATA_SOURCE_URI_FILE)").Default("").String()
+	dataSourceUser        = kingpin.Flag("datasource.user", "Postgres connection user (replaces DATA_SOURCE_USER)").Default("").String()
+	dataSourceUserFile    = kingpin.Flag("datasource.user-file", "Path to a file containing the postgres connection user (replaces DATA_SOURCE_USER_FILE)").Default("").String()
+	dataSourcePass        = kingpin.Flag("datasource.pass", "Postgres connection password (replaces DATA_SOURCE_PASS)").Default("").String()
+	dataSourcePassFile    = kingpin.Flag("datasource.pass-file", "Path to a file containing the postgres connection password (replaces DATA_SOURCE_PASS_FILE)").Default("").String()
 	collectorFlags        = newCollectorFlags()
 	statStatementsFlags   = newPGStatStatementsFlags()
 	logger                = promslog.NewNopLogger()
@@ -141,7 +148,15 @@ func main() {
 		logger.Warn("Error loading config", "err", err)
 	}
 
-	dsns, err := exporter.GetDataSources()
+	dsns, err := exporter.GetDataSources(exporter.DataSourceOpts{
+		DSN:      *dataSourceDSN,
+		URI:      *dataSourceURI,
+		URIFile:  *dataSourceURIFile,
+		User:     *dataSourceUser,
+		UserFile: *dataSourceUserFile,
+		Pass:     *dataSourcePass,
+		PassFile: *dataSourcePassFile,
+	})
 	if err != nil {
 		logger.Error("Failed reading data sources", "err", err.Error())
 		os.Exit(1)

--- a/exporter/datasource.go
+++ b/exporter/datasource.go
@@ -115,48 +115,81 @@ func (e *Exporter) scrapeDSN(ch chan<- prometheus.Metric, dsn string) error {
 	return server.Scrape(ch)
 }
 
+// DataSourceOpts holds the CLI flag values that can be used in place of the
+// DATA_SOURCE_* environment variables. A zero value means "no flag given",
+// which falls back to the environment variable it replaces.
+type DataSourceOpts struct {
+	DSN      string
+	URI      string
+	URIFile  string
+	User     string
+	UserFile string
+	Pass     string
+	PassFile string
+}
+
 // try to get the DataSource
 // DATA_SOURCE_NAME always wins so we do not break older versions
 // reading secrets from files wins over secrets in environment variables
 // DATA_SOURCE_NAME > DATA_SOURCE_{USER|PASS}_FILE > DATA_SOURCE_{USER|PASS}
-func GetDataSources() ([]string, error) {
-	var dsn = os.Getenv("DATA_SOURCE_NAME")
+// The --datasource.* flags take the place of their corresponding env var above
+// whenever they are set.
+func GetDataSources(opts DataSourceOpts) ([]string, error) {
+	var dsn = opts.DSN
+	if len(dsn) == 0 {
+		dsn = os.Getenv("DATA_SOURCE_NAME")
+	}
 	if len(dsn) != 0 {
 		return strings.Split(dsn, ","), nil
 	}
 
 	var user, pass, uri string
 
-	dataSourceUserFile := os.Getenv("DATA_SOURCE_USER_FILE")
+	dataSourceUserFile := opts.UserFile
+	if len(dataSourceUserFile) == 0 {
+		dataSourceUserFile = os.Getenv("DATA_SOURCE_USER_FILE")
+	}
 	if len(dataSourceUserFile) != 0 {
 		fileContents, err := os.ReadFile(dataSourceUserFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed loading data source user file %s: %s", dataSourceUserFile, err.Error())
 		}
 		user = strings.TrimSpace(string(fileContents))
+	} else if len(opts.User) != 0 {
+		user = opts.User
 	} else {
 		user = os.Getenv("DATA_SOURCE_USER")
 	}
 
-	dataSourcePassFile := os.Getenv("DATA_SOURCE_PASS_FILE")
+	dataSourcePassFile := opts.PassFile
+	if len(dataSourcePassFile) == 0 {
+		dataSourcePassFile = os.Getenv("DATA_SOURCE_PASS_FILE")
+	}
 	if len(dataSourcePassFile) != 0 {
 		fileContents, err := os.ReadFile(dataSourcePassFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed loading data source pass file %s: %s", dataSourcePassFile, err.Error())
 		}
 		pass = strings.TrimSpace(string(fileContents))
+	} else if len(opts.Pass) != 0 {
+		pass = opts.Pass
 	} else {
 		pass = os.Getenv("DATA_SOURCE_PASS")
 	}
 
 	ui := url.UserPassword(user, pass).String()
-	dataSrouceURIFile := os.Getenv("DATA_SOURCE_URI_FILE")
+	dataSrouceURIFile := opts.URIFile
+	if len(dataSrouceURIFile) == 0 {
+		dataSrouceURIFile = os.Getenv("DATA_SOURCE_URI_FILE")
+	}
 	if len(dataSrouceURIFile) != 0 {
 		fileContents, err := os.ReadFile(dataSrouceURIFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed loading data source URI file %s: %s", dataSrouceURIFile, err.Error())
 		}
 		uri = strings.TrimSpace(string(fileContents))
+	} else if len(opts.URI) != 0 {
+		uri = opts.URI
 	} else {
 		uri = os.Getenv("DATA_SOURCE_URI")
 	}

--- a/exporter/postgres_exporter_test.go
+++ b/exporter/postgres_exporter_test.go
@@ -125,7 +125,7 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithSecretsFiles(c *C) {
 
 	var expected = "postgresql://custom_username$&+,%2F%3A;=%3F%40:custom_password$&+,%2F%3A;=%3F%40@localhost:5432/?sslmode=disable"
 
-	dsn, err := GetDataSources()
+	dsn, err := GetDataSources(DataSourceOpts{})
 	if err != nil {
 		c.Errorf("Unexpected error reading datasources")
 	}
@@ -145,7 +145,7 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithDns(c *C) {
 	c.Assert(err, IsNil)
 	defer UnsetEnvironment(c, "DATA_SOURCE_NAME")
 
-	dsn, err := GetDataSources()
+	dsn, err := GetDataSources(DataSourceOpts{})
 	if err != nil {
 		c.Errorf("Unexpected error reading datasources")
 	}
@@ -173,7 +173,7 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithDnsAndSecrets(c *C) {
 	c.Assert(err, IsNil)
 	defer UnsetEnvironment(c, "DATA_SOURCE_PASS")
 
-	dsn, err := GetDataSources()
+	dsn, err := GetDataSources(DataSourceOpts{})
 	if err != nil {
 		c.Errorf("Unexpected error reading datasources")
 	}
@@ -183,6 +183,48 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithDnsAndSecrets(c *C) {
 	}
 	if dsn[0] != envDsn {
 		c.Errorf("Expected Username to be read from file. Found=%v, expected=%v", dsn[0], envDsn)
+	}
+}
+
+// test that the --datasource.dsn flag is used even if DATA_SOURCE_NAME is set
+func (s *FunctionalSuite) TestFlagSettingWithDsn(c *C) {
+	err := os.Setenv("DATA_SOURCE_NAME", "postgresql://envUser:envPass@localhost:5432/?sslmode=disable")
+	c.Assert(err, IsNil)
+	defer UnsetEnvironment(c, "DATA_SOURCE_NAME")
+
+	flagDsn := "postgresql://flagUser:flagPass@localhost:5433/?sslmode=enable"
+	dsn, err := GetDataSources(DataSourceOpts{DSN: flagDsn})
+	if err != nil {
+		c.Errorf("Unexpected error reading datasources")
+	}
+
+	if len(dsn) == 0 {
+		c.Errorf("Expected one data source, zero found")
+	}
+	if dsn[0] != flagDsn {
+		c.Errorf("Expected DSN to be read from flag. Found=%v, expected=%v", dsn[0], flagDsn)
+	}
+}
+
+// test that --datasource.user, --datasource.pass and --datasource.uri flags are used
+// when no DATA_SOURCE_* environment variables are set
+func (s *FunctionalSuite) TestFlagSettingWithUserPassUri(c *C) {
+	var expected = "postgresql://flagUser:flagPass@localhost:5432/?sslmode=disable"
+
+	dsn, err := GetDataSources(DataSourceOpts{
+		User: "flagUser",
+		Pass: "flagPass",
+		URI:  "localhost:5432/?sslmode=disable",
+	})
+	if err != nil {
+		c.Errorf("Unexpected error reading datasources")
+	}
+
+	if len(dsn) == 0 {
+		c.Errorf("Expected one data source, zero found")
+	}
+	if dsn[0] != expected {
+		c.Errorf("Expected datasource to be built from flags. Found=%v, expected=%v", dsn[0], expected)
 	}
 }
 


### PR DESCRIPTION
Motivation

exporter/datasource.go's GetDataSources() only reads Postgres connection
config from DATA_SOURCE_NAME, DATA_SOURCE_URI(_FILE), DATA_SOURCE_USER(_FILE)
and DATA_SOURCE_PASS(_FILE) environment variables, with no CLI flag path.
This is part of a broader effort to let CLI flags eventually replace env-var
configuration across the exporter, and the datasource config was the one
remaining piece with no flag equivalent at all.

Approach

Add seven new kingpin flags to cmd/postgres_exporter/main.go: --datasource.dsn,
--datasource.uri, --datasource.uri-file, --datasource.user,
--datasource.user-file, --datasource.pass, --datasource.pass-file. They carry
no Envar() binding since GetDataSources() already owns the env fallback
logic.

GetDataSources() now takes a DataSourceOpts struct instead of no arguments.
For each setting, an explicit flag value takes precedence; when a flag is
empty, behavior falls back exactly to the previous env-var-only logic
(DATA_SOURCE_NAME still short-circuits everything else, file-based secrets
still win over plain values). All new flags default to "", so deployments
that only ever set env vars see no behavior change.

Updated README.md to document the new flags and cross-reference them from
the Environment Variables section, matching how prior flag additions in this
repo have been documented.

Validation

- go build ./... — clean
- go test ./... — all four packages pass; exporter package goes from 9 to
  11 passing cases (added TestFlagSettingWithDsn, confirming the DSN flag
  wins over DATA_SOURCE_NAME, and TestFlagSettingWithUserPassUri, confirming
  a DSN can be built from --datasource.user/--datasource.pass/--datasource.uri
  alone with no env vars set); the three pre-existing env-var tests were
  updated to call GetDataSources(DataSourceOpts{}) and still pass unchanged,
  confirming no behavior change for env-var-only usage
- golangci-lint run ./exporter/... ./cmd/... (version v2.12.2, matching this
  repo's CI) — 0 issues
- gofmt -l on all changed files — clean

Report: https://github.com/prometheus-community/postgres_exporter/issues/1372
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #1372