### PR TITLE
Add --datasource.* CLI flags to replace DATA_SOURCE_* env vars

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -51,6 +51,13 @@ var (
 	includeDatabases      = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled (DEPRECATED)").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
 	metricPrefix          = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
 	collectionTimeout     = kingpin.Flag("collection-timeout", "Timeout for collecting the statistics when the database is slow").Default("1m").Envar("PG_EXPORTER_COLLECTION_TIMEOUT").String()
+	datasourceDSN         = kingpin.Flag("datasource.dsn", "Comma-separated list of data source names. Takes precedence over all other datasource.* flags.").Default("").String()
+	datasourceURI         = kingpin.Flag("datasource.uri", "Data source URI, in host:port/dbname form.").Default("").String()
+	datasourceURIFile     = kingpin.Flag("datasource.uri-file", "Path to a file containing the data source URI. Takes precedence over datasource.uri.").Default("").String()
+	datasourceUser        = kingpin.Flag("datasource.user", "Data source user name.").Default("").String()
+	datasourceUserFile    = kingpin.Flag("datasource.user-file", "Path to a file containing the data source user name. Takes precedence over datasource.user.").Default("").String()
+	datasourcePass        = kingpin.Flag("datasource.pass", "Data source password.").Default("").String()
+	datasourcePassFile    = kingpin.Flag("datasource.pass-file", "Path to a file containing the data source password. Takes precedence over datasource.pass.").Default("").String()
 	collectorFlags        = newCollectorFlags()
 	statStatementsFlags   = newPGStatStatementsFlags()
 	logger                = promslog.NewNopLogger()
@@ -141,7 +148,15 @@ func main() {
 		logger.Warn("Error loading config", "err", err)
 	}
 
-	dsns, err := exporter.GetDataSources()
+	dsns, err := exporter.GetDataSources(exporter.DataSourceOpts{
+		DSN:      *datasourceDSN,
+		URI:      *datasourceURI,
+		URIFile:  *datasourceURIFile,
+		User:     *datasourceUser,
+		UserFile: *datasourceUserFile,
+		Pass:     *datasourcePass,
+		PassFile: *datasourcePassFile,
+	})
 	if err != nil {
 		logger.Error("Failed reading data sources", "err", err.Error())
 		os.Exit(1)

--- a/exporter/datasource.go
+++ b/exporter/datasource.go
@@ -115,19 +115,38 @@ func (e *Exporter) scrapeDSN(ch chan<- prometheus.Metric, dsn string) error {
 	return server.Scrape(ch)
 }
 
+// DataSourceOpts holds the values of the --datasource.* flags. An empty
+// field falls back to the corresponding DATA_SOURCE_* environment variable.
+type DataSourceOpts struct {
+	DSN      string
+	URI      string
+	URIFile  string
+	User     string
+	UserFile string
+	Pass     string
+	PassFile string
+}
+
+func flagOrEnvVar(flagVal, envKey string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	return os.Getenv(envKey)
+}
+
 // try to get the DataSource
-// DATA_SOURCE_NAME always wins so we do not break older versions
-// reading secrets from files wins over secrets in environment variables
-// DATA_SOURCE_NAME > DATA_SOURCE_{USER|PASS}_FILE > DATA_SOURCE_{USER|PASS}
-func GetDataSources() ([]string, error) {
-	var dsn = os.Getenv("DATA_SOURCE_NAME")
+// The --datasource.dsn flag / DATA_SOURCE_NAME env var always wins so we do not break older versions
+// reading secrets from files wins over secrets passed directly
+// dsn > {user|pass}-file > {user|pass}
+func GetDataSources(opts DataSourceOpts) ([]string, error) {
+	dsn := flagOrEnvVar(opts.DSN, "DATA_SOURCE_NAME")
 	if len(dsn) != 0 {
 		return strings.Split(dsn, ","), nil
 	}
 
 	var user, pass, uri string
 
-	dataSourceUserFile := os.Getenv("DATA_SOURCE_USER_FILE")
+	dataSourceUserFile := flagOrEnvVar(opts.UserFile, "DATA_SOURCE_USER_FILE")
 	if len(dataSourceUserFile) != 0 {
 		fileContents, err := os.ReadFile(dataSourceUserFile)
 		if err != nil {
@@ -135,10 +154,10 @@ func GetDataSources() ([]string, error) {
 		}
 		user = strings.TrimSpace(string(fileContents))
 	} else {
-		user = os.Getenv("DATA_SOURCE_USER")
+		user = flagOrEnvVar(opts.User, "DATA_SOURCE_USER")
 	}
 
-	dataSourcePassFile := os.Getenv("DATA_SOURCE_PASS_FILE")
+	dataSourcePassFile := flagOrEnvVar(opts.PassFile, "DATA_SOURCE_PASS_FILE")
 	if len(dataSourcePassFile) != 0 {
 		fileContents, err := os.ReadFile(dataSourcePassFile)
 		if err != nil {
@@ -146,11 +165,11 @@ func GetDataSources() ([]string, error) {
 		}
 		pass = strings.TrimSpace(string(fileContents))
 	} else {
-		pass = os.Getenv("DATA_SOURCE_PASS")
+		pass = flagOrEnvVar(opts.Pass, "DATA_SOURCE_PASS")
 	}
 
 	ui := url.UserPassword(user, pass).String()
-	dataSrouceURIFile := os.Getenv("DATA_SOURCE_URI_FILE")
+	dataSrouceURIFile := flagOrEnvVar(opts.URIFile, "DATA_SOURCE_URI_FILE")
 	if len(dataSrouceURIFile) != 0 {
 		fileContents, err := os.ReadFile(dataSrouceURIFile)
 		if err != nil {
@@ -158,7 +177,7 @@ func GetDataSources() ([]string, error) {
 		}
 		uri = strings.TrimSpace(string(fileContents))
 	} else {
-		uri = os.Getenv("DATA_SOURCE_URI")
+		uri = flagOrEnvVar(opts.URI, "DATA_SOURCE_URI")
 	}
 
 	// No datasources found. This allows us to support the multi-target pattern

--- a/exporter/postgres_exporter_test.go
+++ b/exporter/postgres_exporter_test.go
@@ -125,7 +125,7 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithSecretsFiles(c *C) {
 
 	var expected = "postgresql://custom_username$&+,%2F%3A;=%3F%40:custom_password$&+,%2F%3A;=%3F%40@localhost:5432/?sslmode=disable"
 
-	dsn, err := GetDataSources()
+	dsn, err := GetDataSources(DataSourceOpts{})
 	if err != nil {
 		c.Errorf("Unexpected error reading datasources")
 	}
@@ -145,7 +145,7 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithDns(c *C) {
 	c.Assert(err, IsNil)
 	defer UnsetEnvironment(c, "DATA_SOURCE_NAME")
 
-	dsn, err := GetDataSources()
+	dsn, err := GetDataSources(DataSourceOpts{})
 	if err != nil {
 		c.Errorf("Unexpected error reading datasources")
 	}
@@ -173,7 +173,7 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithDnsAndSecrets(c *C) {
 	c.Assert(err, IsNil)
 	defer UnsetEnvironment(c, "DATA_SOURCE_PASS")
 
-	dsn, err := GetDataSources()
+	dsn, err := GetDataSources(DataSourceOpts{})
 	if err != nil {
 		c.Errorf("Unexpected error reading datasources")
 	}
@@ -183,6 +183,47 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithDnsAndSecrets(c *C) {
 	}
 	if dsn[0] != envDsn {
 		c.Errorf("Expected Username to be read from file. Found=%v, expected=%v", dsn[0], envDsn)
+	}
+}
+
+// test --datasource.* flags: reading secrets from files, plain dsn, and dsn taking
+// precedence over user/pass
+func (s *FunctionalSuite) TestFlagSettingDataSources(c *C) {
+	cases := []struct {
+		name     string
+		opts     DataSourceOpts
+		expected string
+	}{
+		{
+			name: "user and pass read from files",
+			opts: DataSourceOpts{
+				UserFile: "./tests/username_file",
+				PassFile: "./tests/userpass_file",
+				URI:      "localhost:5432/?sslmode=disable",
+			},
+			expected: "postgresql://custom_username$&+,%2F%3A;=%3F%40:custom_password$&+,%2F%3A;=%3F%40@localhost:5432/?sslmode=disable",
+		},
+		{
+			name:     "dsn flag",
+			opts:     DataSourceOpts{DSN: "postgresql://user:password@localhost:5432/?sslmode=enabled"},
+			expected: "postgresql://user:password@localhost:5432/?sslmode=enabled",
+		},
+		{
+			name: "dsn flag wins even if user/pass flags are set",
+			opts: DataSourceOpts{
+				DSN:      "postgresql://userDsn:passwordDsn@localhost:55432/?sslmode=disabled",
+				UserFile: "./tests/username_file",
+				Pass:     "flagUserPass",
+			},
+			expected: "postgresql://userDsn:passwordDsn@localhost:55432/?sslmode=disabled",
+		},
+	}
+
+	for _, cs := range cases {
+		dsn, err := GetDataSources(cs.opts)
+		c.Assert(err, IsNil, Commentf("case %q", cs.name))
+		c.Assert(dsn, HasLen, 1, Commentf("case %q", cs.name))
+		c.Assert(dsn[0], Equals, cs.expected, Commentf("case %q", cs.name))
 	}
 }
 


### PR DESCRIPTION
Closes #1372. Part of #1371.

Adds CLI flags for the Postgres connection config, which was previously only settable via env vars:

- `--datasource.dsn` (replaces `DATA_SOURCE_NAME`)
- `--datasource.uri` (replaces `DATA_SOURCE_URI`) / `--datasource.uri-file` (replaces `DATA_SOURCE_URI_FILE`)
- `--datasource.user` (replaces `DATA_SOURCE_USER`) / `--datasource.user-file` (replaces `DATA_SOURCE_USER_FILE`)
- `--datasource.pass` (replaces `DATA_SOURCE_PASS`) / `--datasource.pass-file` (replaces `DATA_SOURCE_PASS_FILE`)

`GetDataSources()` now takes a `DataSourceOpts` struct. Each field falls back to its existing env var when unset, so behavior is unchanged when only env vars are set. Precedence is unchanged: dsn wins over everything, `*_FILE` wins over the plain value, whether set by flag or env var.

Env vars still work as-is here. Deprecation warnings (#1373) and doc updates (#1374) are separate.