### PR TITLE
Configurable Long running transactions duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ enabling wrapping later will still create this one-time reset boundary.
 
 * [CHANGE] Wrap non-negative 64-bit counters at `2^53` to preserve single-unit precision by @gnanirahulnutakki in https://github.com/prometheus-community/postgres_exporter/pull/1351
 * [CHANGE] stat_replication: add `pid` label to disambiguate replication connections that otherwise share identical labels by @sysadmind in https://github.com/prometheus-community/postgres_exporter/pull/1353
+* [BUGFIX] Fix `long_running_transactions` to count only transactions older than a configurable threshold, by @ArthurSens in https://github.com/prometheus-community/postgres_exporter/pull/1379, based on the contribution by @moreinhardt in https://github.com/prometheus-community/postgres_exporter/pull/1210
 
 ## 0.20.1 / 2026-07-07
 

--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -53,8 +53,14 @@ var (
 	collectionTimeout     = kingpin.Flag("collection-timeout", "Timeout for collecting the statistics when the database is slow").Default("1m").Envar("PG_EXPORTER_COLLECTION_TIMEOUT").String()
 	wrapLargeCounters     = kingpin.Flag("wrap-large-counters", "Wrap 64-bit counters at 2^53 to avoid floating point rounding.").Default("true").Bool()
 	collectorFlags        = newCollectorFlags()
-	statStatementsFlags   = newPGStatStatementsFlags()
-	logger                = promslog.NewNopLogger()
+
+	longRunningTransactionsThreshold = kingpin.Flag(
+		"collector.long_running_transactions.threshold",
+		"Minimum transaction duration to consider long running.",
+	).Default(config.DefaultLongRunningTransactionsThreshold.String()).Duration()
+
+	statStatementsFlags = newPGStatStatementsFlags()
+	logger              = promslog.NewNopLogger()
 )
 
 // The name of the exporter.
@@ -242,6 +248,9 @@ func buildConfig(dsns []string) (config.Config, error) {
 	cfg.ExcludeDatabases = splitList(*excludeDatabases)
 	cfg.IncludeDatabases = splitList(*includeDatabases)
 	cfg.Collectors = collectorFlags.states()
+	cfg.LongRunningTransactions = config.LongRunningTransactionsConfig{
+		Threshold: *longRunningTransactionsThreshold,
+	}
 	cfg.PGStatStatements = config.PGStatStatementsConfig{
 		IncludeQuery:     *statStatementsFlags.includeQuery,
 		QueryLength:      *statStatementsFlags.queryLength,

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -52,9 +52,10 @@ type Collector interface {
 }
 
 type collectorConfig struct {
-	logger                 *slog.Logger
-	excludeDatabases       []string
-	pgStatStatementsConfig config.PGStatStatementsConfig
+	logger                        *slog.Logger
+	excludeDatabases              []string
+	longRunningTransactionsConfig config.LongRunningTransactionsConfig
+	pgStatStatementsConfig        config.PGStatStatementsConfig
 }
 
 func registerCollector(name string, createFunc func(collectorConfig) (Collector, error)) {
@@ -69,11 +70,12 @@ type PostgresCollector struct {
 	Collectors map[string]Collector
 	logger     *slog.Logger
 
-	instance          *instance
-	CollectionTimeout time.Duration
-	collectorStates   map[string]bool
-	pgStatStatements  config.PGStatStatementsConfig
-	wrapLargeCounters bool
+	instance                *instance
+	CollectionTimeout       time.Duration
+	collectorStates         map[string]bool
+	longRunningTransactions config.LongRunningTransactionsConfig
+	pgStatStatements        config.PGStatStatementsConfig
+	wrapLargeCounters       bool
 }
 
 type Option func(*PostgresCollector) error
@@ -81,11 +83,12 @@ type Option func(*PostgresCollector) error
 // NewPostgresCollector creates a new PostgresCollector.
 func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, dsn string, filters []string, options ...Option) (*PostgresCollector, error) {
 	p := &PostgresCollector{
-		logger:            logger,
-		collectorStates:   config.DefaultCollectorConfig(),
-		pgStatStatements:  defaultPGStatStatementsConfig(),
-		CollectionTimeout: time.Minute,
-		wrapLargeCounters: true,
+		logger:                  logger,
+		collectorStates:         config.DefaultCollectorConfig(),
+		longRunningTransactions: defaultLongRunningTransactionsConfig(),
+		pgStatStatements:        defaultPGStatStatementsConfig(),
+		CollectionTimeout:       time.Minute,
+		wrapLargeCounters:       true,
 	}
 	// Apply options to customize the collector
 	for _, o := range options {
@@ -116,9 +119,10 @@ func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, dsn st
 			return nil, fmt.Errorf("missing collector factory: %s", key)
 		}
 		collector, err := factory(collectorConfig{
-			logger:                 logger.With("collector", key),
-			excludeDatabases:       excludeDatabases,
-			pgStatStatementsConfig: p.pgStatStatements,
+			logger:                        logger.With("collector", key),
+			excludeDatabases:              excludeDatabases,
+			longRunningTransactionsConfig: p.longRunningTransactions,
+			pgStatStatementsConfig:        p.pgStatStatements,
 		})
 		if err != nil {
 			return nil, err
@@ -159,6 +163,13 @@ func WithCollectorStates(states map[string]bool) Option {
 func WithPGStatStatementsConfig(cfg config.PGStatStatementsConfig) Option {
 	return func(e *PostgresCollector) error {
 		e.pgStatStatements = withPGStatStatementsDefaults(cfg)
+		return nil
+	}
+}
+
+func WithLongRunningTransactionsConfig(cfg config.LongRunningTransactionsConfig) Option {
+	return func(e *PostgresCollector) error {
+		e.longRunningTransactions = cfg
 		return nil
 	}
 }

--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -17,7 +17,9 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"time"
 
+	"github.com/prometheus-community/postgres_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -26,11 +28,21 @@ func init() {
 }
 
 type PGLongRunningTransactionsCollector struct {
-	log *slog.Logger
+	log       *slog.Logger
+	threshold time.Duration
 }
 
-func NewPGLongRunningTransactionsCollector(config collectorConfig) (Collector, error) {
-	return &PGLongRunningTransactionsCollector{log: config.logger}, nil
+func defaultLongRunningTransactionsConfig() config.LongRunningTransactionsConfig {
+	return config.LongRunningTransactionsConfig{
+		Threshold: config.DefaultLongRunningTransactionsThreshold,
+	}
+}
+
+func NewPGLongRunningTransactionsCollector(cfg collectorConfig) (Collector, error) {
+	return &PGLongRunningTransactionsCollector{
+		log:       cfg.logger,
+		threshold: cfg.longRunningTransactionsConfig.Threshold,
+	}, nil
 }
 
 var (
@@ -54,17 +66,18 @@ var (
     MAX(EXTRACT(EPOCH FROM clock_timestamp() - pg_stat_activity.xact_start)) AS oldest_timestamp_seconds
 FROM pg_catalog.pg_stat_activity
 WHERE state IS DISTINCT FROM 'idle'
-AND (now() - pg_stat_activity.xact_start) > '1 minutes'::interval
+AND (now() - pg_stat_activity.xact_start) > make_interval(secs => $1)
 AND query NOT LIKE 'autovacuum:%'
 AND pg_stat_activity.xact_start IS NOT NULL
 AND pid <> pg_backend_pid();
 	`
 )
 
-func (PGLongRunningTransactionsCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGLongRunningTransactionsCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
-		longRunningTransactionsQuery)
+		longRunningTransactionsQuery,
+		c.threshold.Seconds())
 
 	if err != nil {
 		return err

--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -54,6 +54,7 @@ var (
     MAX(EXTRACT(EPOCH FROM clock_timestamp() - pg_stat_activity.xact_start)) AS oldest_timestamp_seconds
 FROM pg_catalog.pg_stat_activity
 WHERE state IS DISTINCT FROM 'idle'
+AND (now() - pg_stat_activity.xact_start) > '1 minutes'::interval
 AND query NOT LIKE 'autovacuum:%'
 AND pg_stat_activity.xact_start IS NOT NULL
 AND pid <> pg_backend_pid();

--- a/collector/pg_long_running_transactions_integration_test.go
+++ b/collector/pg_long_running_transactions_integration_test.go
@@ -1,0 +1,62 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestPGLongRunningTransactionsCollectorFiltersByThreshold(t *testing.T) {
+	db, err := sql.Open("postgres", os.Getenv("DATA_SOURCE_NAME"))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer db.Close()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	defer tx.Rollback()
+	time.Sleep(10 * time.Millisecond)
+
+	inst := &instance{db: db}
+	if got := collectLongRunningTransactionsCount(t, inst, time.Millisecond); got < 1 {
+		t.Fatalf("transaction count with 1ms threshold = %v, want at least 1", got)
+	}
+	if got := collectLongRunningTransactionsCount(t, inst, 24*time.Hour); got != 0 {
+		t.Fatalf("transaction count with 24h threshold = %v, want 0", got)
+	}
+}
+
+func collectLongRunningTransactionsCount(t *testing.T, inst *instance, threshold time.Duration) float64 {
+	t.Helper()
+
+	ch := make(chan prometheus.Metric, 2)
+	collector := PGLongRunningTransactionsCollector{threshold: threshold}
+	if err := collector.Update(context.Background(), inst, ch); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	return readMetric(<-ch).value
+}

--- a/collector/pg_long_running_transactions_test.go
+++ b/collector/pg_long_running_transactions_test.go
@@ -15,6 +15,7 @@ package collector
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,12 +37,14 @@ func TestPGLongRunningTransactionsCollector(t *testing.T) {
 	rows := sqlmock.NewRows(columns).
 		AddRow(20, 1200)
 
-	mock.ExpectQuery(sanitizeQuery(longRunningTransactionsQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(longRunningTransactionsQuery)).
+		WithArgs((5 * time.Minute).Seconds()).
+		WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
-		c := PGLongRunningTransactionsCollector{}
+		c := PGLongRunningTransactionsCollector{threshold: 5 * time.Minute}
 
 		if err := c.Update(context.Background(), inst, ch); err != nil {
 			t.Errorf("Error calling PGLongRunningTransactionsCollector.Update: %s", err)
@@ -77,12 +80,14 @@ func TestPGLongRunningTransactionsCollectorNull(t *testing.T) {
 	rows := sqlmock.NewRows(columns).
 		AddRow(0, nil)
 
-	mock.ExpectQuery(sanitizeQuery(longRunningTransactionsQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery(longRunningTransactionsQuery)).
+		WithArgs(time.Minute.Seconds()).
+		WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
-		c := PGLongRunningTransactionsCollector{}
+		c := PGLongRunningTransactionsCollector{threshold: time.Minute}
 
 		if err := c.Update(context.Background(), inst, ch); err != nil {
 			t.Errorf("Error calling PGLongRunningTransactionsCollector.Update: %s", err)

--- a/collector/runtime.go
+++ b/collector/runtime.go
@@ -54,6 +54,7 @@ func NewRuntime(validatedConfig config.ValidatedConfig, logger *slog.Logger) (*R
 		nil,
 		WithCollectionTimeout(cfg.CollectionTimeout.String()),
 		WithCollectorStates(cfg.Collectors),
+		WithLongRunningTransactionsConfig(cfg.LongRunningTransactions),
 		WithPGStatStatementsConfig(cfg.PGStatStatements),
 		WithWrapLargeCounters(cfg.WrapLargeCounters),
 	)

--- a/collector/runtime_test.go
+++ b/collector/runtime_test.go
@@ -15,6 +15,7 @@ package collector
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus-community/postgres_exporter/config"
 	"github.com/prometheus/common/promslog"
@@ -92,5 +93,30 @@ func TestNewRuntimePropagatesWrapLargeCounters(t *testing.T) {
 
 	if runtime.postgresCollector.instance.wrapLargeCounters {
 		t.Fatal("postgres collector wrapLargeCounters = true, want false")
+	}
+}
+
+func TestNewRuntimePropagatesLongRunningTransactionsThreshold(t *testing.T) {
+	cfg := config.NewConfigWithDefaults()
+	cfg.DataSourceNames = []string{"postgresql://localhost:5432/postgres?sslmode=disable"}
+	cfg.Collectors[config.CollectorLongRunningTransactions] = true
+	cfg.LongRunningTransactions.Threshold = 5 * time.Minute
+	validated, err := cfg.Validate()
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	runtime, err := NewRuntime(validated, promslog.NewNopLogger())
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+	defer runtime.Close()
+
+	collector, ok := runtime.postgresCollector.Collectors[config.CollectorLongRunningTransactions].(*PGLongRunningTransactionsCollector)
+	if !ok {
+		t.Fatalf("collector type = %T, want *PGLongRunningTransactionsCollector", collector)
+	}
+	if got, want := collector.threshold, 5*time.Minute; got != want {
+		t.Fatalf("threshold = %v, want %v", got, want)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,8 @@ const (
 	DefaultMetricPrefix      string        = "pg"
 	DefaultCollectionTimeout time.Duration = time.Minute
 
+	DefaultLongRunningTransactionsThreshold time.Duration = time.Minute
+
 	DefaultPGStatStatementsIncludeQuery bool = false
 	DefaultPGStatStatementsQueryLength  uint = 120
 	DefaultPGStatStatementsLimit        uint = 100
@@ -67,18 +69,19 @@ const (
 )
 
 type Config struct {
-	DataSourceNames       []string
-	MetricPrefix          string
-	CollectionTimeout     time.Duration
-	WrapLargeCounters     bool
-	DisableDefaultMetrics bool
-	AutoDiscoverDatabases bool
-	UserQueriesPath       string
-	ConstantLabels        string
-	ExcludeDatabases      []string
-	IncludeDatabases      []string
-	Collectors            map[string]bool
-	PGStatStatements      PGStatStatementsConfig
+	DataSourceNames         []string
+	MetricPrefix            string
+	CollectionTimeout       time.Duration
+	WrapLargeCounters       bool
+	DisableDefaultMetrics   bool
+	AutoDiscoverDatabases   bool
+	UserQueriesPath         string
+	ConstantLabels          string
+	ExcludeDatabases        []string
+	IncludeDatabases        []string
+	Collectors              map[string]bool
+	LongRunningTransactions LongRunningTransactionsConfig
+	PGStatStatements        PGStatStatementsConfig
 }
 
 // ValidatedConfig is the result of a successful Config.Validate call. It holds
@@ -112,12 +115,19 @@ type PGStatStatementsConfig struct {
 	ExcludeUsers     []string
 }
 
+type LongRunningTransactionsConfig struct {
+	Threshold time.Duration
+}
+
 func NewConfigWithDefaults() Config {
 	return Config{
 		MetricPrefix:      DefaultMetricPrefix,
 		CollectionTimeout: DefaultCollectionTimeout,
 		WrapLargeCounters: true,
 		Collectors:        DefaultCollectorConfig(),
+		LongRunningTransactions: LongRunningTransactionsConfig{
+			Threshold: DefaultLongRunningTransactionsThreshold,
+		},
 		PGStatStatements: PGStatStatementsConfig{
 			IncludeQuery: DefaultPGStatStatementsIncludeQuery,
 			QueryLength:  DefaultPGStatStatementsQueryLength,
@@ -137,6 +147,9 @@ func (c Config) Validate() (ValidatedConfig, error) {
 	}
 	if c.CollectionTimeout <= 0 {
 		return ValidatedConfig{}, fmt.Errorf("collection timeout must be greater than zero")
+	}
+	if c.LongRunningTransactions.Threshold <= 0 {
+		return ValidatedConfig{}, fmt.Errorf("long running transactions threshold must be greater than zero")
 	}
 	for i, dsn := range c.DataSourceNames {
 		if dsn == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,9 @@ func TestNewConfigWithDefaults(t *testing.T) {
 	if got, want := cfg.CollectionTimeout, DefaultCollectionTimeout; got != want {
 		t.Fatalf("CollectionTimeout = %v, want %v", got, want)
 	}
+	if got, want := cfg.LongRunningTransactions.Threshold, DefaultLongRunningTransactionsThreshold; got != want {
+		t.Fatalf("LongRunningTransactions.Threshold = %v, want %v", got, want)
+	}
 	if !cfg.WrapLargeCounters {
 		t.Fatal("WrapLargeCounters = false, want true")
 	}
@@ -135,6 +138,13 @@ func TestConfigValidateFailures(t *testing.T) {
 				cfg.CollectionTimeout = 0
 			},
 			want: "collection timeout must be greater than zero",
+		},
+		{
+			name: "zero long running transactions threshold",
+			mutate: func(cfg *Config) {
+				cfg.LongRunningTransactions.Threshold = 0
+			},
+			want: "long running transactions threshold must be greater than zero",
 		},
 		{
 			name: "empty data source",


### PR DESCRIPTION
Continuing the work made by @moreinhardt to make sure long-running transactions only count queries that take longer than a configurable threshold, instead of counting all queries.