### PR TITLE
Add LICENSE and NOTICE to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/postgres_exporter /bin/postgres_exporter
+COPY LICENSE /LICENSE
+COPY NOTICE /NOTICE
 
 EXPOSE     9187
 USER       nobody


### PR DESCRIPTION
The container images published for postgres_exporter only contain the binary, so anyone redistributing the image has no copy of the Apache-2.0 license text or the NOTICE file, even though `.promu.yml` already ships both in the release tarballs. This was reported in #1206, where SuperQ noted it's "Probably worth adding a COPY to the Dockerfile."

This adds `COPY LICENSE /LICENSE` and `COPY NOTICE /NOTICE` to the Dockerfile, following the same convention as the prometheus/prometheus Dockerfile. Both files live at the repo root, which is the docker build context (`DOCKERBUILD_CONTEXT ?= ./`), and neither is excluded by `.dockerignore`, so no other changes are needed.

Fixes #1206
