### PR TITLE
fix: skip autovacuum metric when xact_start is NULL

### DIFF
--- a/collector/pg_stat_activity_autovacuum.go
+++ b/collector/pg_stat_activity_autovacuum.go
@@ -15,6 +15,7 @@ package collector
 
 import (
 	"context"
+	"database/sql"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -51,7 +52,7 @@ var (
 	`
 )
 
-func (PGStatActivityAutovacuumCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGStatActivityAutovacuumCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		statActivityAutovacuumQuery)
@@ -63,16 +64,21 @@ func (PGStatActivityAutovacuumCollector) Update(ctx context.Context, instance *i
 
 	for rows.Next() {
 		var relname string
-		var ageInSeconds float64
+		var ageInSeconds sql.NullFloat64
 
 		if err := rows.Scan(&relname, &ageInSeconds); err != nil {
 			return err
 		}
 
+		if !ageInSeconds.Valid {
+			c.log.Debug("Skipping collecting metric because it has no xact_start")
+			continue
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			statActivityAutovacuumAgeInSeconds,
 			prometheus.GaugeValue,
-			ageInSeconds, relname,
+			ageInSeconds.Float64, relname,
 		)
 	}
 	if err := rows.Err(); err != nil {

--- a/collector/pg_stat_activity_autovacuum_test.go
+++ b/collector/pg_stat_activity_autovacuum_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/promslog"
 	"github.com/smartystreets/goconvey/convey"
 )
 
@@ -42,6 +43,46 @@ func TestPGStatActivityAutovacuumCollector(t *testing.T) {
 	go func() {
 		defer close(ch)
 		c := PGStatActivityAutovacuumCollector{}
+
+		if err := c.Update(context.Background(), inst, ch); err != nil {
+			t.Errorf("Error calling PGStatActivityAutovacuumCollector.Update: %s", err)
+		}
+	}()
+	expected := []MetricResult{
+		{labels: labelMap{"relname": "test"}, value: 3600, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			m := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, m)
+		}
+	})
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}
+
+func TestPGStatActivityAutovacuumCollectorNullTimestamp(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening a stub db connection: %s", err)
+	}
+	defer db.Close()
+	inst := &instance{db: db}
+	columns := []string{
+		"relname",
+		"timestamp_seconds",
+	}
+	rows := sqlmock.NewRows(columns).
+		AddRow("no_xact_start", nil).
+		AddRow("test", 3600)
+
+	mock.ExpectQuery(sanitizeQuery(statActivityAutovacuumQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		c := PGStatActivityAutovacuumCollector{log: promslog.NewNopLogger()}
 
 		if err := c.Update(context.Background(), inst, ch); err != nil {
 			t.Errorf("Error calling PGStatActivityAutovacuumCollector.Update: %s", err)


### PR DESCRIPTION
The stat_activity_autovacuum collector scans `EXTRACT(EPOCH FROM xact_start)` into a plain `float64`. `xact_start` can be NULL for autovacuum workers, and when that happens the Scan fails with `converting NULL to float64 is unsupported` and the entire collector errors out, as reported in #952.

This changes the scan target to `sql.NullFloat64` and skips the row when the value is NULL, following the same pattern the pg_stat_walreceiver and pg_stat_database collectors use. Skipping rather than reporting 0 matches sysadmind's comment on the issue: "The typical options are to report a 0 value or to skip the metric all together. I usually lean towards the latter." Rows with a valid timestamp keep being emitted as before.

The regression test adds a NULL-timestamp row mixed with a normal row; it reproduces the exact Scan error before the fix and verifies the NULL row is skipped and the valid row still emitted after.

Fixes #952
