### PR TITLE
Fix loggableDSN for query string parameters

### DIFF
--- a/config/dsn.go
+++ b/config/dsn.go
@@ -62,6 +62,11 @@ func (d DSN) GetConnectionString() string {
 	return u.String()
 }
 
+// NewDSN parses a connection string into a DSN.
+func NewDSN(in string) (DSN, error) {
+	return dsnFromString(in)
+}
+
 // dsnFromString parses a connection string into a dsn. It will attempt to parse the string as
 // a URL and as a set of key=value pairs. If both attempts fail, dsnFromString will return an error.
 func dsnFromString(in string) (DSN, error) {

--- a/config/dsn_test.go
+++ b/config/dsn_test.go
@@ -16,6 +16,7 @@ package config
 import (
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -97,6 +98,50 @@ func Test_dsn_String(t *testing.T) {
 			}
 			if got := d.String(); got != tt.want {
 				t.Errorf("dsn.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_dsn_String_Redacted tests the parse-then-print round trip that log lines rely on:
+// no matter which form the password arrives in, it must not survive into dsn.String().
+// https://github.com/prometheus-community/postgres_exporter/issues/643
+func TestDSNStringRedacted(t *testing.T) {
+	const password = "S3CRET"
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "password in userinfo",
+			input: "postgresql://user:" + password + "@localhost:5432/postgres?sslmode=disable",
+		},
+		{
+			name:  "password as a query parameter",
+			input: "postgresql://localhost:5432/postgres?user=test&password=" + password + "&sslmode=disable",
+		},
+		{
+			name:  "password in a key=value connection string",
+			input: "host=localhost port=5432 user=test password=" + password + " sslmode=disable",
+		},
+		{
+			name:  "quoted password in a key=value connection string",
+			input: "host=localhost user=test password='" + password + " with spaces' sslmode=disable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := dsnFromString(tt.input)
+			if err != nil {
+				t.Fatalf("dsnFromString(%q) error = %v", tt.input, err)
+			}
+			got := d.String()
+			if strings.Contains(got, password) {
+				t.Errorf("dsn.String() leaked the password: %v", got)
+			}
+			if !strings.Contains(got, "******") {
+				t.Errorf("dsn.String() did not redact the password: %v", got)
 			}
 		})
 	}

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus-community/postgres_exporter/config"
 	"github.com/prometheus-community/postgres_exporter/internal/metricutil"
 )
 
@@ -225,15 +226,15 @@ func parseFingerprint(dsn string) (string, error) {
 	return fingerprint, nil
 }
 
+// loggableDSN returns a redacted representation of dsn that is safe to log. Passwords are
+// stripped whether they are supplied in the URL user info, as a query parameter, or as a
+// key=value keyword. It never returns the original dsn, so an unparseable input is reported
+// without echoing it back.
 func loggableDSN(dsn string) string {
-	pDSN, err := url.Parse(dsn)
+	d, err := config.NewDSN(dsn)
 	if err != nil {
 		return "could not parse DATA_SOURCE_NAME"
 	}
-	// Blank user info if not nil
-	if pDSN.User != nil {
-		pDSN.User = url.UserPassword(pDSN.User.Username(), "PASSWORD_REMOVED")
-	}
 
-	return pDSN.String()
+	return d.String()
 }


### PR DESCRIPTION
Fix loggableDSN redaction of sensitive values when passed by query string parameters. The config.DSN was already safe for this purpose, so instead of duplicating logic, this moves loggableDSN to use that type instead.

fixes #643